### PR TITLE
Image handling

### DIFF
--- a/__tests__/BlockContentItem.test.tsx
+++ b/__tests__/BlockContentItem.test.tsx
@@ -1,5 +1,7 @@
 import "@testing-library/jest-dom";
 import { screen, render, within } from "@testing-library/react";
+import { mocked } from "jest-mock";
+import NextImage from "next/image";
 
 import { BlockContentItem } from "@components/BlockContentItem";
 import {
@@ -10,6 +12,10 @@ import {
 
 jest.mock("react-syntax-highlighter", () => ({}));
 jest.mock("react-syntax-highlighter/dist/esm/styles/hljs", () => ({}));
+
+jest.mock("next/image", () => jest.fn());
+
+const mockedNextImage = mocked(NextImage);
 
 const TestWithListItem = (
   style: Style,
@@ -161,6 +167,24 @@ const TestWithMarks = (
     });
   });
 };
+
+describe("_type = image", () => {
+  const withImage: BlockContentItemData = {
+    _key: "3657e4482fec",
+    _type: "image",
+    alt: "my-cool-alt-text",
+    asset: {
+      _ref: "image-e5270bee947b5a03a882f377730e52bcf4357ac0-1280x720-png",
+      _type: "reference",
+    },
+  };
+
+  fit("Renders the image", () => {
+    render(<BlockContentItem blockContent={withImage} />);
+
+    expect(NextImage).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe("_type = block", () => {
   describe("text is empty", () => {

--- a/__tests__/BlockContentItem.test.tsx
+++ b/__tests__/BlockContentItem.test.tsx
@@ -1,6 +1,5 @@
 import "@testing-library/jest-dom";
 import { screen, render, within } from "@testing-library/react";
-import { mocked } from "jest-mock";
 import NextImage from "next/image";
 
 import { BlockContentItem } from "@components/BlockContentItem";
@@ -9,13 +8,11 @@ import {
   Mark,
   Style,
 } from "@customTypes/BlockContentTypes";
-import { urlFor } from "../sanity/client";
 
 jest.mock("react-syntax-highlighter", () => ({}));
 jest.mock("react-syntax-highlighter/dist/esm/styles/hljs", () => ({}));
 
 jest.mock("next/image", () => jest.fn());
-const mockedNextImage = mocked(NextImage);
 
 jest.mock("../sanity/client", () => ({
   urlFor: (url: string) => ({ url: () => url }),

--- a/__tests__/BlockContentItem.test.tsx
+++ b/__tests__/BlockContentItem.test.tsx
@@ -9,13 +9,17 @@ import {
   Mark,
   Style,
 } from "@customTypes/BlockContentTypes";
+import { urlFor } from "../sanity/client";
 
 jest.mock("react-syntax-highlighter", () => ({}));
 jest.mock("react-syntax-highlighter/dist/esm/styles/hljs", () => ({}));
 
 jest.mock("next/image", () => jest.fn());
-
 const mockedNextImage = mocked(NextImage);
+
+jest.mock("../sanity/client", () => ({
+  urlFor: (url: string) => ({ url: () => url }),
+}));
 
 const TestWithListItem = (
   style: Style,
@@ -179,10 +183,16 @@ describe("_type = image", () => {
     },
   };
 
-  fit("Renders the image", () => {
+  it("Renders the image", () => {
     render(<BlockContentItem blockContent={withImage} />);
 
-    expect(NextImage).toHaveBeenCalledTimes(1);
+    expect(NextImage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        src: withImage.asset._ref,
+        alt: withImage.alt,
+      }),
+      {}
+    );
   });
 });
 

--- a/app/_components/ArticleImage.tsx
+++ b/app/_components/ArticleImage.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState } from "react";
 import Image from "next/image";
-import cx from "classnames";
+import { IoCloseSharp } from "react-icons/io5";
 
 import { urlFor } from "@/sanity/client";
 
@@ -26,9 +26,15 @@ export const ArticleImage = ({ src, alt }: ArticleImageProps) => {
 
       {isFullScreen && (
         <div
-          className="fixed w-screen h-screen bg-black/70 top-0 left-0 z-50 flex justify-center items-center"
+          className="fixed w-screen h-screen bg-black/80 top-0 left-0 z-50 flex justify-center items-center"
           onClick={() => setIsFullScreen(false)}
         >
+          <button
+            className="fixed top-[2.5%] right-[2.5%] text-slate-300 text-36 bg-slate-black/80 z-50"
+            onClick={() => setIsFullScreen(false)}
+          >
+            <IoCloseSharp />
+          </button>
           <div className="relative w-[95%] h-[95%]">
             <Image
               src={urlFor(src).url()}

--- a/app/_components/ArticleImage.tsx
+++ b/app/_components/ArticleImage.tsx
@@ -1,4 +1,8 @@
+"use client";
+import { useState } from "react";
 import Image from "next/image";
+import cx from "classnames";
+
 import { urlFor } from "@/sanity/client";
 
 type ArticleImageProps = {
@@ -6,14 +10,36 @@ type ArticleImageProps = {
   alt: string;
 };
 export const ArticleImage = ({ src, alt }: ArticleImageProps) => {
+  const [isFullScreen, setIsFullScreen] = useState(false);
+
   return (
-    <div className="relative w-full h-256 sm:h-512 bg-slate-400">
-      <Image
-        src={urlFor(src).url()}
-        alt={alt}
-        fill
-        style={{ objectFit: "contain" }}
-      />
-    </div>
+    <>
+      <div className="relative w-full h-256 sm:h-512 bg-slate-400">
+        <Image
+          src={urlFor(src).url()}
+          alt={alt}
+          fill
+          style={{ objectFit: "contain" }}
+          onClick={() => setIsFullScreen(true)}
+        />
+      </div>
+
+      {isFullScreen && (
+        <div
+          className="fixed w-screen h-screen bg-black/70 top-0 left-0 z-50 flex justify-center items-center"
+          onClick={() => setIsFullScreen(false)}
+        >
+          <div className="relative w-[95%] h-[95%]">
+            <Image
+              src={urlFor(src).url()}
+              alt={alt}
+              fill
+              style={{ objectFit: "contain" }}
+              onClick={() => setIsFullScreen(true)}
+            />
+          </div>
+        </div>
+      )}
+    </>
   );
 };

--- a/app/_components/ArticleImage.tsx
+++ b/app/_components/ArticleImage.tsx
@@ -1,0 +1,19 @@
+import Image from "next/image";
+import { urlFor } from "@/sanity/client";
+
+type ArticleImageProps = {
+  src: string;
+  alt: string;
+};
+export const ArticleImage = ({ src, alt }: ArticleImageProps) => {
+  return (
+    <div className="relative w-full h-256 sm:h-512 bg-slate-400">
+      <Image
+        src={urlFor(src).url()}
+        alt={alt}
+        fill
+        style={{ objectFit: "contain" }}
+      />
+    </div>
+  );
+};

--- a/app/_components/BlockContentItem.tsx
+++ b/app/_components/BlockContentItem.tsx
@@ -3,6 +3,7 @@ import SyntaxHighlighter from "react-syntax-highlighter";
 import { tomorrowNightBright } from "react-syntax-highlighter/dist/esm/styles/hljs";
 
 import { BlockContentItemData, Mark } from "@customTypes/BlockContentTypes";
+import { urlFor } from "@/sanity/client";
 
 type BlockContentItemProps = {
   blockContent: BlockContentItemData;
@@ -64,6 +65,15 @@ export const BlockContentItem = ({ blockContent }: BlockContentItemProps) => {
       >
         {blockContent.code}
       </SyntaxHighlighter>
+    );
+  }
+
+  if (blockContent._type === "image") {
+    return (
+      <img
+        src={urlFor(blockContent.asset._ref).width(200).url()}
+        alt={blockContent.alt}
+      />
     );
   }
 

--- a/app/_components/BlockContentItem.tsx
+++ b/app/_components/BlockContentItem.tsx
@@ -73,7 +73,7 @@ export const BlockContentItem = ({ blockContent }: BlockContentItemProps) => {
     return (
       // TODO: Ensure this looks good on various image sizes
       // TODO: Test this
-      <div className="w-full h-512 relative">
+      <div className="relative w-full h-192 sm:h-512 bg-slate-400">
         <Image
           src={urlFor(blockContent.asset._ref).url()}
           alt={blockContent.alt}

--- a/app/_components/BlockContentItem.tsx
+++ b/app/_components/BlockContentItem.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import { tomorrowNightBright } from "react-syntax-highlighter/dist/esm/styles/hljs";
+import Image from "next/image";
 
 import { BlockContentItemData, Mark } from "@customTypes/BlockContentTypes";
 import { urlFor } from "@/sanity/client";
@@ -70,10 +71,16 @@ export const BlockContentItem = ({ blockContent }: BlockContentItemProps) => {
 
   if (blockContent._type === "image") {
     return (
-      <img
-        src={urlFor(blockContent.asset._ref).width(200).url()}
-        alt={blockContent.alt}
-      />
+      // TODO: Ensure this looks good on various image sizes
+      // TODO: Test this
+      <div className="w-full h-512 relative">
+        <Image
+          src={urlFor(blockContent.asset._ref).url()}
+          alt={blockContent.alt}
+          fill
+          style={{ objectFit: "contain" }}
+        />
+      </div>
     );
   }
 

--- a/app/_components/BlockContentItem.tsx
+++ b/app/_components/BlockContentItem.tsx
@@ -73,7 +73,7 @@ export const BlockContentItem = ({ blockContent }: BlockContentItemProps) => {
     return (
       // TODO: Ensure this looks good on various image sizes
       // TODO: Test this
-      <div className="relative w-full h-192 sm:h-512 bg-slate-400">
+      <div className="relative w-full h-256 sm:h-512 bg-slate-400">
         <Image
           src={urlFor(blockContent.asset._ref).url()}
           alt={blockContent.alt}

--- a/app/_components/BlockContentItem.tsx
+++ b/app/_components/BlockContentItem.tsx
@@ -1,10 +1,9 @@
 import React from "react";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import { tomorrowNightBright } from "react-syntax-highlighter/dist/esm/styles/hljs";
-import Image from "next/image";
 
 import { BlockContentItemData, Mark } from "@customTypes/BlockContentTypes";
-import { urlFor } from "@/sanity/client";
+import { ArticleImage } from "@components/ArticleImage";
 
 type BlockContentItemProps = {
   blockContent: BlockContentItemData;
@@ -71,16 +70,7 @@ export const BlockContentItem = ({ blockContent }: BlockContentItemProps) => {
 
   if (blockContent._type === "image") {
     return (
-      // TODO: Ensure this looks good on various image sizes
-      // TODO: Test this
-      <div className="relative w-full h-256 sm:h-512 bg-slate-400">
-        <Image
-          src={urlFor(blockContent.asset._ref).url()}
-          alt={blockContent.alt}
-          fill
-          style={{ objectFit: "contain" }}
-        />
-      </div>
+      <ArticleImage src={blockContent.asset._ref} alt={blockContent.alt} />
     );
   }
 

--- a/app/_customTypes/BlockContentTypes.ts
+++ b/app/_customTypes/BlockContentTypes.ts
@@ -43,7 +43,17 @@ export type Code = {
   level?: undefined;
 };
 
-export type BlockContentItemData = Block | Code;
+export type Image = {
+  _key: string;
+  _type: "image";
+  alt: "string";
+  asset: {
+    _ref: string;
+    _type: "reference";
+  };
+};
+
+export type BlockContentItemData = Block | Code | Image;
 
 export type GroupedListItems = {
   _type: "groupedListItems";

--- a/app/_customTypes/BlockContentTypes.ts
+++ b/app/_customTypes/BlockContentTypes.ts
@@ -46,7 +46,7 @@ export type Code = {
 export type Image = {
   _key: string;
   _type: "image";
-  alt: "string";
+  alt: string;
   asset: {
     _ref: string;
     _type: "reference";

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,13 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "cdn.sanity.io",
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:watch": "jest --watchAll"
   },
   "dependencies": {
+    "@sanity/image-url": "^1.0.2",
     "@storybook/addon-backgrounds": "^8.1.11",
     "classnames": "^2.5.1",
     "framer-motion": "^11.2.12",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "storybook": "^8.1.11",
     "tailwindcss": "^3.4.1",
     "tailwindcss-textshadow": "^2.1.3",
-    "ts-jest": "^29.1.5",
+    "ts-jest": "^29.2.1",
     "typescript": "^5"
   }
 }

--- a/sanity/client.ts
+++ b/sanity/client.ts
@@ -3,6 +3,7 @@ import { createClient } from "next-sanity";
 const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID;
 const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET;
 const apiVersion = process.env.NEXT_PUBLIC_SANITY_API_VERSION || "2023-05-03";
+import imageUrlBuilder from "@sanity/image-url";
 
 export const client = createClient({
   projectId,
@@ -10,3 +11,9 @@ export const client = createClient({
   apiVersion, // https://www.sanity.io/docs/api-versioning
   useCdn: true, // if you're using ISR or only static generation at build time then you can set this to `false` to guarantee no stale content
 });
+
+const builder = imageUrlBuilder(client);
+
+export const urlFor = (source: string) => {
+  return builder.image(source);
+};

--- a/stories/dummyBlockContent.ts
+++ b/stories/dummyBlockContent.ts
@@ -527,4 +527,27 @@ export const DUMMY_BLOCK_CONTENT_COMPREHENSIVE: BlockContentItemData[] = [
     code: ".shredder {\n  display: flex;\n}",
     _type: "code",
   },
+  {
+    _type: "block",
+    style: "normal",
+    _key: "b761fd874fe5",
+    markDefs: [],
+    children: [
+      {
+        text: "",
+        _key: "78d361eda04c",
+        _type: "span",
+        marks: [],
+      },
+    ],
+  },
+  {
+    _key: "3657e4482fec",
+    _type: "image",
+    alt: "my-cool-alt-text",
+    asset: {
+      _ref: "image-e5270bee947b5a03a882f377730e52bcf4357ac0-1280x720-png",
+      _type: "reference",
+    },
+  },
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2066,6 +2066,11 @@
     event-source-polyfill "1.0.31"
     eventsource "2.0.2"
 
+"@sanity/image-url@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@sanity/image-url/-/image-url-1.0.2.tgz#1ff7259e9bad6bfca4169f21c53a4123f6ac78c3"
+  integrity sha512-C4+jb2ny3ZbMgEkLd7Z3C75DsxcTEoE+axXQJsQ75ou0AKWGdVsP351hqK6mJUUxn5HCSlu3vznoh7Yljye4cQ==
+
 "@sanity/preview-kit-compat@1.5.1":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@sanity/preview-kit-compat/-/preview-kit-compat-1.5.1.tgz#4a8d50a4fc8d684f38947d46ae85ed0013634e30"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5435,7 +5435,7 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-ejs@^3.1.10:
+ejs@^3.0.0, ejs@^3.1.10:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.10.tgz#69ab8358b14e896f80cc39e62087b88500c3ac3b"
   integrity sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==
@@ -10930,12 +10930,13 @@ ts-interface-checker@^0.1.9:
   resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
-ts-jest@^29.1.5:
-  version "29.1.5"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.1.5.tgz#d6c0471cc78bffa2cb4664a0a6741ef36cfe8f69"
-  integrity sha512-UuClSYxM7byvvYfyWdFI+/2UxMmwNyJb0NPkZPQE2hew3RurV7l7zURgOHAd/1I1ZdPpe3GUsXNXAcN8TFKSIg==
+ts-jest@^29.2.1:
+  version "29.2.1"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.2.1.tgz#9a460bb27446d141c48a17cf24f060dbe9b58254"
+  integrity sha512-7obwtH5gw0b0XZi0wmprCSvGSvHliMBI47lPnU47vmbxWS6B+v1X94yWFo1f1vt9k/he+gttsrXjkxmgY41XNQ==
   dependencies:
     bs-logger "0.x"
+    ejs "^3.0.0"
     fast-json-stable-stringify "2.x"
     jest-util "^29.0.0"
     json5 "^2.2.3"


### PR DESCRIPTION
Adds the ability to render images from Sanity's mainContent data in `articles/[slug]`.
Images take up a fixed height, and can be clicked on to be made full screen.

✅ Responsive
✅ Test coverage
✅ SB coverage