### PR TITLE
Handle japanese blog content

### DIFF
--- a/app/(routes)/articles/[slug]/page.tsx
+++ b/app/(routes)/articles/[slug]/page.tsx
@@ -20,11 +20,14 @@ type Tag = {
 type ArticleData = {
   _createdAt: string;
   title: string;
+  jpTitle: string;
   slug: Slug;
   description: string;
+  jpDescription: string;
   tags: Tag[];
-  titleImage: typeof Image;
+  jpTags: Tag[];
   mainContent: BlockContentItemData[];
+  jpMainContent: BlockContentItemData[];
 };
 export async function generateStaticParams() {
   const res = await client.fetch<ArticleData[]>(SLUGS_QUERY);
@@ -49,11 +52,14 @@ export default async function Page({ params }: ArticleProps) {
     ]{
       _createdAt,
       title,
+      jpTitle,
       slug,
       description,
+      jpDescription,
       tags,
-      titleImage,
+      jpTags,
       mainContent,
+      jpMainContent
     }[0]
   `);
 
@@ -64,9 +70,13 @@ export default async function Page({ params }: ArticleProps) {
   const {
     _createdAt: createdAt,
     title,
+    jpTitle,
     description,
+    jpDescription,
     tags,
+    jpTags,
     mainContent,
+    jpMainContent,
   } = article;
 
   return (
@@ -77,9 +87,13 @@ export default async function Page({ params }: ArticleProps) {
           <Article
             createdAt={createdAt}
             title={title}
+            jpTitle={jpTitle}
             description={description}
+            jpDescription={jpDescription}
             tags={tags}
+            jpTags={jpTags}
             mainContent={mainContent}
+            jpMainContent={jpMainContent}
           />
         </div>
       </div>

--- a/app/(routes)/articles/[slug]/page.tsx
+++ b/app/(routes)/articles/[slug]/page.tsx
@@ -17,7 +17,7 @@ type Slug = {
 type Tag = {
   value: string;
 };
-type ArticleData = {
+export type ArticleData = {
   _createdAt: string;
   title: string;
   jpTitle: string;

--- a/app/(routes)/articles/page.tsx
+++ b/app/(routes)/articles/page.tsx
@@ -2,6 +2,7 @@ import { SanityDocument } from "next-sanity";
 
 import { client } from "@/sanity/client";
 import { MobileArticleLinks } from "@components/MobileArticleLinks";
+import { ArticleData } from "@/app/(routes)/articles/[slug]/page";
 
 const EVENTS_QUERY = `
 *[
@@ -9,16 +10,19 @@ const EVENTS_QUERY = `
 ]{
   _createdAt,
   title,
+  jpTitle,
   slug,
   description,
+  jpDescription,
   tags,
-  titleImage,
+  jpTags,
   mainContent,
+  jpMainContent,
 } | order(_createdAt desc)
 `;
 
 const getArticles = async () => {
-  const res = await client.fetch<SanityDocument[]>(EVENTS_QUERY);
+  const res = await client.fetch<ArticleData[]>(EVENTS_QUERY);
   return res;
 };
 

--- a/app/_components/Article.tsx
+++ b/app/_components/Article.tsx
@@ -2,11 +2,13 @@
 import { Bebas_Neue } from "next/font/google";
 import cx from "classnames";
 import { motion } from "framer-motion";
+import { useIntl } from "react-intl";
 
 import { FormattedDate } from "@components/FormattedDate";
 import { BlockContent } from "@components/BlockContent";
 import { BlockContentItemData } from "@customTypes/BlockContentTypes";
 import { Tag } from "@components/Tag";
+import { useEffect, useState, useMemo } from "react";
 
 const bebasNeue = Bebas_Neue({
   weight: "400",
@@ -41,6 +43,41 @@ export const Article = ({
   mainContent,
   jpMainContent,
 }: ArticleProps) => {
+  const intl = useIntl();
+  const { locale } = intl;
+
+  const enContent = useMemo(
+    () => ({
+      title,
+      description,
+      tags,
+      mainContent,
+    }),
+    []
+  );
+  const jpContent = useMemo(
+    () => ({
+      title: jpTitle,
+      description: jpDescription,
+      tags: jpTags,
+      mainContent: jpMainContent,
+    }),
+    []
+  );
+  const [content, setContent] = useState(enContent);
+  useEffect(() => {
+    switch (locale) {
+      case "en-uk":
+        setContent(enContent);
+        break;
+      case "ja-jp":
+        setContent(jpContent);
+        break;
+      default:
+        setContent(enContent);
+    }
+  }, [locale, enContent, jpContent]);
+
   return (
     <motion.div
       initial="hidden"
@@ -50,14 +87,16 @@ export const Article = ({
       transition={{ staggerChildren: 0.04 }}
     >
       <div className="w-full shadow-lg border-1 border-slate-600 p-8 sm:p-16 mb-16">
-        <h1 className={cx("text-24 mb-8", bebasNeue.className)}>{title}</h1>
+        <h1 className={cx("text-24 mb-8", bebasNeue.className)}>
+          {content.title}
+        </h1>
 
         <h3 className="border-l-8 border-slate-800 pl-8 mb-12">
-          {description}
+          {content.description}
         </h3>
 
         <div className="flex flex-wrap mb-8">
-          {tags.map(({ value }, i) => (
+          {content.tags.map(({ value }, i) => (
             <Tag label={value} key={value + i} />
           ))}
         </div>
@@ -70,7 +109,7 @@ export const Article = ({
 
       {/* Main content */}
       <div className="w-full shadow-lg border-1 border-slate-600 p-8 sm:p-16 mb-16">
-        {<BlockContent blockContent={mainContent} />}
+        {<BlockContent blockContent={content.mainContent} />}
       </div>
     </motion.div>
   );

--- a/app/_components/Article.tsx
+++ b/app/_components/Article.tsx
@@ -53,7 +53,7 @@ export const Article = ({
       tags,
       mainContent,
     }),
-    []
+    [title, description, tags, mainContent]
   );
   const jpContent = useMemo(
     () => ({
@@ -62,7 +62,7 @@ export const Article = ({
       tags: jpTags,
       mainContent: jpMainContent,
     }),
-    []
+    [jpTitle, jpDescription, jpTags, jpMainContent]
   );
   const [content, setContent] = useState(enContent);
   useEffect(() => {

--- a/app/_components/Article.tsx
+++ b/app/_components/Article.tsx
@@ -16,9 +16,13 @@ const bebasNeue = Bebas_Neue({
 type ArticleProps = {
   createdAt: string;
   title: string;
+  jpTitle: string;
   description: string;
+  jpDescription: string;
   tags: { value: string }[];
+  jpTags: { value: string }[];
   mainContent: BlockContentItemData[];
+  jpMainContent: BlockContentItemData[];
 };
 
 const containerVariants = {
@@ -29,9 +33,13 @@ const containerVariants = {
 export const Article = ({
   createdAt,
   title,
+  jpTitle,
   description,
+  jpDescription,
   tags,
+  jpTags,
   mainContent,
+  jpMainContent,
 }: ArticleProps) => {
   return (
     <motion.div

--- a/app/_components/MobileArticleLinks.tsx
+++ b/app/_components/MobileArticleLinks.tsx
@@ -1,15 +1,61 @@
 "use client";
-import { useRef, useEffect } from "react";
-import { MobileArticleLink } from "./MobileArticleLink";
-import { SanityDocument } from "next-sanity";
-import { Inter } from "next/font/google";
+import { useState, useRef, useEffect, useMemo } from "react";
+import { useIntl } from "react-intl";
+import { MobileArticleLink, ArticleProps } from "./MobileArticleLink";
 import mobileArticleLinkStyles from "./mobileArticleLink.module.css";
+import { ArticleData } from "@/app/(routes)/articles/[slug]/page";
 
 type Props = {
-  articles: SanityDocument[];
+  articles: ArticleData[];
 };
 export const MobileArticleLinks = ({ articles }: Props) => {
   const containerRef = useRef<HTMLDivElement>(null);
+  const intl = useIntl();
+  const { locale } = intl;
+
+  const localisedArticleSets = useMemo(() => {
+    const enArticles: ArticleProps[] = [];
+    const jpArticles: ArticleProps[] = [];
+
+    articles.forEach((article) => {
+      enArticles.push({
+        title: article.title,
+        description: article.description,
+        tags: article.tags,
+        createdAt: article._createdAt,
+        slug: article.slug.current,
+      });
+      jpArticles.push({
+        title: article.jpTitle,
+        description: article.jpDescription,
+        tags: article.jpTags,
+        createdAt: article._createdAt,
+        slug: article.slug.current,
+      });
+    });
+
+    return {
+      enArticles,
+      jpArticles,
+    };
+  }, [articles]);
+
+  const [localisedArticles, setLocalisedArticles] = useState(
+    localisedArticleSets.enArticles
+  );
+
+  useEffect(() => {
+    switch (locale) {
+      case "en-uk":
+        setLocalisedArticles(localisedArticleSets.enArticles);
+        break;
+      case "ja-jp":
+        setLocalisedArticles(localisedArticleSets.jpArticles);
+        break;
+      default:
+        setLocalisedArticles(localisedArticleSets.enArticles);
+    }
+  }, [locale, localisedArticleSets]);
 
   const intersectionObserver = new IntersectionObserver(
     (entries) => {
@@ -31,13 +77,13 @@ export const MobileArticleLinks = ({ articles }: Props) => {
 
   return (
     <div className="w-full flex flex-col items-center mt-12" ref={containerRef}>
-      {articles.map((article, i) => (
+      {localisedArticles.map((article, i) => (
         <MobileArticleLink
           key={article.title + i}
           title={article.title}
-          slug={article.slug.current}
+          slug={article.slug}
           description={article.description}
-          createdAt={article._createdAt}
+          createdAt={article.createdAt}
           tags={article.tags}
           interSectionObserver={intersectionObserver}
         />


### PR DESCRIPTION
Handles incoming Japanese data from Sanity. Renders Japanese content when locale is set to `"ja-jp"`, and English content otherwise.