### PR TITLE
Return null when no localisedArticles

### DIFF
--- a/app/_components/MobileArticleLinks.tsx
+++ b/app/_components/MobileArticleLinks.tsx
@@ -75,6 +75,10 @@ export const MobileArticleLinks = ({ articles }: Props) => {
     }
   );
 
+  if (!localisedArticles) {
+    return null;
+  }
+
   return (
     <div className="w-full flex flex-col items-center mt-12" ref={containerRef}>
       {localisedArticles.map((article, i) => (


### PR DESCRIPTION
There seems to be an issue in prod where there's no `localisedArticles` when first rendering the `articles` page. Seeing if this fixes the issue.