### PR TITLE
Fix blockquote styles

### DIFF
--- a/__tests__/BlockContentItem.test.tsx
+++ b/__tests__/BlockContentItem.test.tsx
@@ -268,7 +268,7 @@ describe("_type = block", () => {
 
       const element = screen.getByTestId("blockContent-blockquote");
 
-      expect(element.nodeName).toBe("P");
+      expect(element.nodeName).toBe("DIV");
       expect(element.classList.contains("border-l-4")).toBe(true);
       expect(element.classList.contains("bg-slate-400")).toBe(true);
     });

--- a/app/_components/BlockContentItem.tsx
+++ b/app/_components/BlockContentItem.tsx
@@ -4,6 +4,7 @@ import { tomorrowNightBright } from "react-syntax-highlighter/dist/esm/styles/hl
 
 import { BlockContentItemData, Mark } from "@customTypes/BlockContentTypes";
 import { ArticleImage } from "@components/ArticleImage";
+import { isBlock } from "typescript";
 
 type BlockContentItemProps = {
   blockContent: BlockContentItemData;
@@ -18,6 +19,24 @@ const WithListItem = ({ listItem, children }: WithListItemProps) => {
     return <li data-testid="blockContent-li">{children}</li>;
   }
   return <div className="my-8">{children}</div>;
+};
+
+type WithBlockQuoteProps = {
+  isBlockQuote: boolean;
+  children: React.ReactNode;
+};
+const WithBlockQuote = ({ isBlockQuote, children }: WithBlockQuoteProps) => {
+  if (isBlockQuote) {
+    return (
+      <div
+        className="border-l-4 border-slate-900 bg-slate-400 pl-4"
+        data-testid="blockContent-blockquote"
+      >
+        {children}
+      </div>
+    );
+  }
+  return children;
 };
 
 type WithMarksProps = {
@@ -78,90 +97,84 @@ export const BlockContentItem = ({ blockContent }: BlockContentItemProps) => {
     const { _type, style, children, listItem } = blockContent;
     return (
       <WithListItem listItem={listItem}>
-        {children.map((child, i) => {
-          if (child.text === "")
-            return <br key={i} data-testid="blockContent-br" />;
-          if (style === "normal")
-            return (
-              <p
-                key={i}
-                className="text-slate-900 inline"
-                data-testid="blockContent-p"
-              >
-                <WithMarks blockChild={child} />
-              </p>
-            );
-          if (style === "h1")
-            return (
-              <h1
-                className="text-30 text-slate-900 inline"
-                key={i}
-                data-testid="blockContent-h1"
-              >
-                <WithMarks blockChild={child} />
-              </h1>
-            );
-          if (style === "h2")
-            return (
-              <h2
-                className="text-24 text-slate-900 inline"
-                key={i}
-                data-testid="blockContent-h2"
-              >
-                <WithMarks blockChild={child} />
-              </h2>
-            );
-          if (style === "h3")
-            return (
-              <h3
-                className="text-20 text-slate-900 inline"
-                key={i}
-                data-testid="blockContent-h3"
-              >
-                <WithMarks blockChild={child} />
-              </h3>
-            );
-          if (style === "h4")
-            return (
-              <h4
-                className="text-18 text-slate-900 inline"
-                key={i}
-                data-testid="blockContent-h4"
-              >
-                <WithMarks blockChild={child} />
-              </h4>
-            );
-          if (style === "h5")
-            return (
-              <h5
-                className="text-16 text-slate-900 inline"
-                key={i}
-                data-testid="blockContent-h5"
-              >
-                <WithMarks blockChild={child} />
-              </h5>
-            );
-          if (style === "h6")
-            return (
-              <h6
-                className="text-14 text-slate-900 inline"
-                key={i}
-                data-testid="blockContent-h6"
-              >
-                <WithMarks blockChild={child} />
-              </h6>
-            );
-          if (style === "blockquote")
-            return (
-              <p
-                className="border-l-4 pl-4 bg-slate-400"
-                key={i}
-                data-testid="blockContent-blockquote"
-              >
-                <WithMarks blockChild={child} />
-              </p>
-            );
-        })}
+        <WithBlockQuote isBlockQuote={style === "blockquote"}>
+          {children.map((child, i) => {
+            if (child.text === "")
+              return <br key={i} data-testid="blockContent-br" />;
+            if (style === "normal")
+              return (
+                <p
+                  key={i}
+                  className="text-slate-900 inline"
+                  data-testid="blockContent-p"
+                >
+                  <WithMarks blockChild={child} />
+                </p>
+              );
+            if (style === "h1")
+              return (
+                <h1
+                  className="text-30 text-slate-900 inline"
+                  key={i}
+                  data-testid="blockContent-h1"
+                >
+                  <WithMarks blockChild={child} />
+                </h1>
+              );
+            if (style === "h2")
+              return (
+                <h2
+                  className="text-24 text-slate-900 inline"
+                  key={i}
+                  data-testid="blockContent-h2"
+                >
+                  <WithMarks blockChild={child} />
+                </h2>
+              );
+            if (style === "h3")
+              return (
+                <h3
+                  className="text-20 text-slate-900 inline"
+                  key={i}
+                  data-testid="blockContent-h3"
+                >
+                  <WithMarks blockChild={child} />
+                </h3>
+              );
+            if (style === "h4")
+              return (
+                <h4
+                  className="text-18 text-slate-900 inline"
+                  key={i}
+                  data-testid="blockContent-h4"
+                >
+                  <WithMarks blockChild={child} />
+                </h4>
+              );
+            if (style === "h5")
+              return (
+                <h5
+                  className="text-16 text-slate-900 inline"
+                  key={i}
+                  data-testid="blockContent-h5"
+                >
+                  <WithMarks blockChild={child} />
+                </h5>
+              );
+            if (style === "h6")
+              return (
+                <h6
+                  className="text-14 text-slate-900 inline"
+                  key={i}
+                  data-testid="blockContent-h6"
+                >
+                  <WithMarks blockChild={child} />
+                </h6>
+              );
+            if (style === "blockquote")
+              return <WithMarks blockChild={child} key={i} />;
+          })}
+        </WithBlockQuote>
       </WithListItem>
     );
   }

--- a/app/_components/BlockContentItem.tsx
+++ b/app/_components/BlockContentItem.tsx
@@ -4,7 +4,6 @@ import { tomorrowNightBright } from "react-syntax-highlighter/dist/esm/styles/hl
 
 import { BlockContentItemData, Mark } from "@customTypes/BlockContentTypes";
 import { ArticleImage } from "@components/ArticleImage";
-import { isBlock } from "typescript";
 
 type BlockContentItemProps = {
   blockContent: BlockContentItemData;

--- a/app/_components/BlockContentItem.tsx
+++ b/app/_components/BlockContentItem.tsx
@@ -154,7 +154,7 @@ export const BlockContentItem = ({ blockContent }: BlockContentItemProps) => {
           if (style === "blockquote")
             return (
               <p
-                className="border-l-4 bg-slate-400  inline"
+                className="border-l-4 pl-4 bg-slate-400"
                 key={i}
                 data-testid="blockContent-blockquote"
               >

--- a/app/_components/BlockContentItem.tsx
+++ b/app/_components/BlockContentItem.tsx
@@ -62,7 +62,7 @@ const WithMarks = ({ blockChild }: WithMarksProps) => {
   if (marks.includes("code")) {
     element = (
       <code
-        className="bg-slate-900 text-slate-300 "
+        className="bg-slate-900 text-slate-300 px-4"
         data-testid="blockContent-code"
       >
         {element}

--- a/stories/BlockContentItem.stories.tsx
+++ b/stories/BlockContentItem.stories.tsx
@@ -10,6 +10,7 @@ import {
   DUMMY_BLOCK_CONTENT_INLINE_CODE,
   DUMMY_BLOCK_CONTENT_WITH_CODE_BLOCK,
   DUMMY_BLOCK_CONTENT_WITH_BOTH_LISTS,
+  DUMMY_BLOCK_CONTENT_WITH_LONG_BLOCKQUOTE,
   DUMMY_BLOCK_CONTENT_COMPREHENSIVE,
 } from "./dummyBlockContent";
 
@@ -92,6 +93,14 @@ export const BlockStrongEmUnderlineStrikethrough: Story = {
 export const BlockInlineCode: Story = {
   render: () => {
     return <BlockContent blockContent={DUMMY_BLOCK_CONTENT_INLINE_CODE} />;
+  },
+};
+
+export const WithLongBlockQuote: Story = {
+  render: () => {
+    return (
+      <BlockContent blockContent={DUMMY_BLOCK_CONTENT_WITH_LONG_BLOCKQUOTE} />
+    );
   },
 };
 

--- a/stories/BlockContentItem.stories.tsx
+++ b/stories/BlockContentItem.stories.tsx
@@ -10,7 +10,7 @@ import {
   DUMMY_BLOCK_CONTENT_INLINE_CODE,
   DUMMY_BLOCK_CONTENT_WITH_CODE_BLOCK,
   DUMMY_BLOCK_CONTENT_WITH_BOTH_LISTS,
-  DUMMY_BLOCK_CONTENT_WITH_LONG_BLOCKQUOTE,
+  DUMMY_BLOCK_CONTENT_WITH_LONG_BLOCKQUOTE_AND_CODE,
   DUMMY_BLOCK_CONTENT_COMPREHENSIVE,
 } from "./dummyBlockContent";
 
@@ -99,7 +99,9 @@ export const BlockInlineCode: Story = {
 export const WithLongBlockQuote: Story = {
   render: () => {
     return (
-      <BlockContent blockContent={DUMMY_BLOCK_CONTENT_WITH_LONG_BLOCKQUOTE} />
+      <BlockContent
+        blockContent={DUMMY_BLOCK_CONTENT_WITH_LONG_BLOCKQUOTE_AND_CODE}
+      />
     );
   },
 };

--- a/stories/dummyBlockContent.ts
+++ b/stories/dummyBlockContent.ts
@@ -70,6 +70,24 @@ export const DUMMY_BLOCK_CONTENT_WITH_CODE_BLOCK: BlockContentItemData[] = [
   generateWithUniqueStyle("normal"),
 ];
 
+export const DUMMY_BLOCK_CONTENT_WITH_LONG_BLOCKQUOTE: BlockContentItemData[] =
+  [
+    {
+      _key: "123",
+      markDefs: [],
+      children: [
+        {
+          _type: "span",
+          marks: [],
+          text: `This is a really long block quote. When this wraps around, the dark border should remain consistent of the left side. Tutant meenage neetle teetles have been running amuck.`,
+          _key: "123",
+        },
+      ],
+      _type: "block",
+      style: "blockquote",
+    },
+  ];
+
 const ul1_1: BlockContentItemData = {
   _type: "block",
   style: "normal",

--- a/stories/dummyBlockContent.ts
+++ b/stories/dummyBlockContent.ts
@@ -70,7 +70,7 @@ export const DUMMY_BLOCK_CONTENT_WITH_CODE_BLOCK: BlockContentItemData[] = [
   generateWithUniqueStyle("normal"),
 ];
 
-export const DUMMY_BLOCK_CONTENT_WITH_LONG_BLOCKQUOTE: BlockContentItemData[] =
+export const DUMMY_BLOCK_CONTENT_WITH_LONG_BLOCKQUOTE_AND_CODE: BlockContentItemData[] =
   [
     {
       _key: "123",
@@ -79,7 +79,19 @@ export const DUMMY_BLOCK_CONTENT_WITH_LONG_BLOCKQUOTE: BlockContentItemData[] =
         {
           _type: "span",
           marks: [],
-          text: `This is a really long block quote. When this wraps around, the dark border should remain consistent of the left side. Tutant meenage neetle teetles have been running amuck.`,
+          text: `This is a really long block quote. When this wraps around, the dark border should remain consistent of the left side. Tutant meenage neetle teetles have been running amuck. `,
+          _key: "123",
+        },
+        {
+          _type: "span",
+          marks: ["code"],
+          text: `some code`,
+          _key: "123",
+        },
+        {
+          _type: "span",
+          marks: [],
+          text: ` Here's some more text. This whole thing should be inline`,
           _key: "123",
         },
       ],


### PR DESCRIPTION
After publishing the first article, there was an issue in the styles of blockquotes. Blockquotes that wrap or have multiple children end up looking like this:

<img width="463" alt="image" src="https://github.com/user-attachments/assets/0d151868-7466-4621-b62d-fe5a93f0c1ac">

Essentially, each child is being wrapped in its own block content styles, which leads to discontinuation when wrapping, and a `border-left` for each child.

✅ Adds regression story to demonstrate wrapped blockquote with code inside
✅ Adds missing `padding-left` to blockquotes
✅ Sets the color of the `border-left` to `slate-900` instead of the default `black`
✅  Wraps all children of blockquote in a single div with one border, and one dark background
✅  Updates tests
✅  Adds some minor x padding to inline code

Looks like this now:
<img width="632" alt="image" src="https://github.com/user-attachments/assets/3d3bab15-e3d1-42e4-b26a-c78b95d3ae74">
