### PR TITLE
Use dvh for screen height & reset autofill styles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -13,3 +13,23 @@
     @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-900 focus-visible:border-transparent;
   }
 }
+
+/* Reset autofill styles for input */
+/* Selecting an autofill option would normally set the input
+   background to white */
+input:-webkit-autofill,
+input:-webkit-autofill:hover, 
+input:-webkit-autofill:focus, 
+input:-webkit-autofill:active{
+    -webkit-box-shadow: 0 0 0 30px #CDC8B0 inset !important;
+    -webkit-text-fill-color: #4E4B42 !important;
+    outline-style: solid;
+}
+input:-webkit-autofill:focus, 
+input:-webkit-autofill:active{
+  /* border: 2px solid #4E4B42; */
+  outline: 2px solid #4E4B42;
+  outline-offset: 2px;
+  /* border-color: #CDC8B0; */
+  border-color: transparent;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -28,7 +28,7 @@ export default function RootLayout({
         <UserSettingsContextProvider>
           <AnimationContextProvider>
             <I18nProvider>
-              <div className="w-screen h-screen flex flex-col">
+              <div className="w-screen h-[100dvh] flex flex-col">
                 <Navbar />
                 <MainContentWrapper>{children}</MainContentWrapper>
               </div>


### PR DESCRIPTION
Some minor style changes:
- Sets the app height based on `dvh` instead of `vh`
- Overrides default `input` styles. Difference shown below:

Before:
<img width="625" alt="image" src="https://github.com/user-attachments/assets/36423365-0363-4536-8fb4-586319a1f1f5">

After:
<img width="642" alt="image" src="https://github.com/user-attachments/assets/19dac25c-57c8-4fc3-b15a-cc9e228827ee">
