### PR TITLE
Handle links

### DIFF
--- a/__tests__/BlockContentItem.test.tsx
+++ b/__tests__/BlockContentItem.test.tsx
@@ -104,7 +104,6 @@ const TestWithMarks = (
   });
   describe("marks includes 'underline'", () => {
     it("Wraps contents of element in <u>", () => {
-      const text = "Hello";
       const blockContent: BlockContentItemData = generatePropsWithMarks([
         "underline",
       ]);

--- a/__tests__/BlockContentItem.test.tsx
+++ b/__tests__/BlockContentItem.test.tsx
@@ -6,6 +6,7 @@ import { BlockContentItem } from "@components/BlockContentItem";
 import {
   BlockContentItemData,
   Mark,
+  MarkDef,
   Style,
 } from "@customTypes/BlockContentTypes";
 
@@ -60,12 +61,15 @@ const TestWithMarks = (
   testId: string,
   listItem?: "bullet" | "number"
 ) => {
-  const generatePropsWithMarks = (marks: Mark[]): BlockContentItemData => {
+  const generatePropsWithMarks = (
+    marks: Mark[],
+    markDefs: MarkDef[] = []
+  ): BlockContentItemData => {
     const listItemProps = listItem ? { listItem: listItem, level: 1 } : {};
     return {
       _type: "block",
       _key: "123",
-      markDefs: [],
+      markDefs,
       style: style,
       children: [
         {
@@ -86,7 +90,7 @@ const TestWithMarks = (
       const element = screen.getByTestId(testId);
       const em = within(element).getByTestId("blockContent-em");
 
-      expect(em).toBeInTheDocument();
+      expect(em.nodeName).toBe("EM");
     });
   });
   describe("marks includes 'strong'", () => {
@@ -99,7 +103,7 @@ const TestWithMarks = (
       const element = screen.getByTestId(testId);
       const strong = within(element).getByTestId("blockContent-strong");
 
-      expect(strong).toBeInTheDocument();
+      expect(strong.nodeName).toBe("STRONG");
     });
   });
   describe("marks includes 'underline'", () => {
@@ -112,7 +116,7 @@ const TestWithMarks = (
       const element = screen.getByTestId(testId);
       const underline = within(element).getByTestId("blockContent-u");
 
-      expect(underline).toBeInTheDocument();
+      expect(underline.nodeName).toBe("U");
     });
   });
   describe("marks includes 'strikethrough'", () => {
@@ -125,7 +129,7 @@ const TestWithMarks = (
       const element = screen.getByTestId(testId);
       const strikethrough = within(element).getByTestId("blockContent-s");
 
-      expect(strikethrough).toBeInTheDocument();
+      expect(strikethrough.nodeName).toBe("S");
     });
   });
   describe("marks includes 'code'", () => {
@@ -139,6 +143,22 @@ const TestWithMarks = (
       const code = within(element).getByTestId("blockContent-code");
 
       expect(code).toBeInTheDocument();
+    });
+  });
+  describe("marks includes a non-standard string", () => {
+    describe("mark references a markDef of _type='link'", () => {
+      it("Wraps contents of element in <a>", () => {
+        const blockContent: BlockContentItemData = generatePropsWithMarks(
+          ["123"],
+          [{ _type: "link", href: "https://example.com", _key: "123" }]
+        );
+        render(<BlockContentItem blockContent={blockContent} />);
+
+        const element = screen.getByTestId(testId);
+        const a = within(element).getByTestId("blockContent-a");
+
+        expect(a.nodeName).toBe("A");
+      });
     });
   });
   describe("marks include 'strong', 'em', 'underline', 'strikethrough' and 'code'", () => {
@@ -159,10 +179,10 @@ const TestWithMarks = (
       const s = within(element).getByTestId("blockContent-s");
       const code = within(element).getByTestId("blockContent-code");
 
-      expect(strong).toBeInTheDocument();
-      expect(em).toBeInTheDocument();
-      expect(u).toBeInTheDocument();
-      expect(s).toBeInTheDocument();
+      expect(strong.nodeName).toBe("STRONG");
+      expect(em.nodeName).toBe("EM");
+      expect(u.nodeName).toBe("U");
+      expect(s.nodeName).toBe("S");
       expect(code).toBeInTheDocument();
     });
   });

--- a/app/_components/BlockContentItem.tsx
+++ b/app/_components/BlockContentItem.tsx
@@ -76,7 +76,12 @@ const WithMarks = ({ blockChild, markDefs }: WithMarksProps) => {
       markDefs?.forEach((markDef) => {
         if (markDef._key === mark && markDef._type === "link") {
           element = (
-            <a className="underline" target="_blank" href={markDef.href}>
+            <a
+              className="underline"
+              target="_blank"
+              href={markDef.href}
+              data-testid="blockContent-a"
+            >
               {element}
             </a>
           );

--- a/app/_components/BlockContentItem.tsx
+++ b/app/_components/BlockContentItem.tsx
@@ -47,7 +47,7 @@ type WithMarksProps = {
     text: string | null;
     marks: Mark[];
   };
-  markDefs: MarkDef[];
+  markDefs: MarkDef[] | undefined;
 };
 const WithMarks = ({ blockChild, markDefs }: WithMarksProps) => {
   const { text, marks } = blockChild;

--- a/app/_components/BlockContentItem.tsx
+++ b/app/_components/BlockContentItem.tsx
@@ -2,7 +2,11 @@ import React from "react";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import { tomorrowNightBright } from "react-syntax-highlighter/dist/esm/styles/hljs";
 
-import { BlockContentItemData, Mark } from "@customTypes/BlockContentTypes";
+import {
+  BlockContentItemData,
+  Mark,
+  MarkDef,
+} from "@customTypes/BlockContentTypes";
 import { ArticleImage } from "@components/ArticleImage";
 
 type BlockContentItemProps = {
@@ -43,32 +47,43 @@ type WithMarksProps = {
     text: string | null;
     marks: Mark[];
   };
+  markDefs: MarkDef[];
 };
-const WithMarks = ({ blockChild }: WithMarksProps) => {
+const WithMarks = ({ blockChild, markDefs }: WithMarksProps) => {
   const { text, marks } = blockChild;
   let element: React.ReactNode = text;
-  if (marks.includes("strong")) {
-    element = <strong data-testid="blockContent-strong">{element}</strong>;
-  }
-  if (marks.includes("em")) {
-    element = <em data-testid="blockContent-em">{element}</em>;
-  }
-  if (marks.includes("underline")) {
-    element = <u data-testid="blockContent-u">{element}</u>;
-  }
-  if (marks.includes("strike-through")) {
-    element = <s data-testid="blockContent-s">{element}</s>;
-  }
-  if (marks.includes("code")) {
-    element = (
-      <code
-        className="bg-slate-900 text-slate-300 px-4"
-        data-testid="blockContent-code"
-      >
-        {element}
-      </code>
-    );
-  }
+  marks.forEach((mark) => {
+    if (mark === "strong") {
+      element = <strong data-testid="blockContent-strong">{element}</strong>;
+    } else if (mark === "em") {
+      element = <em data-testid="blockContent-em">{element}</em>;
+    } else if (mark === "underline") {
+      element = <u data-testid="blockContent-u">{element}</u>;
+    } else if (mark === "strike-through") {
+      element = <s data-testid="blockContent-s">{element}</s>;
+    } else if (mark === "code") {
+      element = (
+        <code
+          className="bg-slate-900 text-slate-300 px-4"
+          data-testid="blockContent-code"
+        >
+          {element}
+        </code>
+      );
+    } else {
+      // In this case, mark may be a reference to a markdef _key field
+      // Checks to see if corresponding markDef exists, and wraps according to type
+      markDefs?.forEach((markDef) => {
+        if (markDef._key === mark && markDef._type === "link") {
+          element = (
+            <a className="underline" target="_blank" href={markDef.href}>
+              {element}
+            </a>
+          );
+        }
+      });
+    }
+  });
   return element;
 };
 
@@ -93,7 +108,7 @@ export const BlockContentItem = ({ blockContent }: BlockContentItemProps) => {
   }
 
   if (blockContent._type === "block") {
-    const { _type, style, children, listItem } = blockContent;
+    const { _type, style, children, listItem, markDefs } = blockContent;
     return (
       <WithListItem listItem={listItem}>
         <WithBlockQuote isBlockQuote={style === "blockquote"}>
@@ -107,7 +122,7 @@ export const BlockContentItem = ({ blockContent }: BlockContentItemProps) => {
                   className="text-slate-900 inline"
                   data-testid="blockContent-p"
                 >
-                  <WithMarks blockChild={child} />
+                  <WithMarks blockChild={child} markDefs={markDefs} />
                 </p>
               );
             if (style === "h1")
@@ -117,7 +132,7 @@ export const BlockContentItem = ({ blockContent }: BlockContentItemProps) => {
                   key={i}
                   data-testid="blockContent-h1"
                 >
-                  <WithMarks blockChild={child} />
+                  <WithMarks blockChild={child} markDefs={markDefs} />
                 </h1>
               );
             if (style === "h2")
@@ -127,7 +142,7 @@ export const BlockContentItem = ({ blockContent }: BlockContentItemProps) => {
                   key={i}
                   data-testid="blockContent-h2"
                 >
-                  <WithMarks blockChild={child} />
+                  <WithMarks blockChild={child} markDefs={markDefs} />
                 </h2>
               );
             if (style === "h3")
@@ -137,7 +152,7 @@ export const BlockContentItem = ({ blockContent }: BlockContentItemProps) => {
                   key={i}
                   data-testid="blockContent-h3"
                 >
-                  <WithMarks blockChild={child} />
+                  <WithMarks blockChild={child} markDefs={markDefs} />
                 </h3>
               );
             if (style === "h4")
@@ -147,7 +162,7 @@ export const BlockContentItem = ({ blockContent }: BlockContentItemProps) => {
                   key={i}
                   data-testid="blockContent-h4"
                 >
-                  <WithMarks blockChild={child} />
+                  <WithMarks blockChild={child} markDefs={markDefs} />
                 </h4>
               );
             if (style === "h5")
@@ -157,7 +172,7 @@ export const BlockContentItem = ({ blockContent }: BlockContentItemProps) => {
                   key={i}
                   data-testid="blockContent-h5"
                 >
-                  <WithMarks blockChild={child} />
+                  <WithMarks blockChild={child} markDefs={markDefs} />
                 </h5>
               );
             if (style === "h6")
@@ -167,11 +182,13 @@ export const BlockContentItem = ({ blockContent }: BlockContentItemProps) => {
                   key={i}
                   data-testid="blockContent-h6"
                 >
-                  <WithMarks blockChild={child} />
+                  <WithMarks blockChild={child} markDefs={markDefs} />
                 </h6>
               );
             if (style === "blockquote")
-              return <WithMarks blockChild={child} key={i} />;
+              return (
+                <WithMarks blockChild={child} key={i} markDefs={markDefs} />
+              );
           })}
         </WithBlockQuote>
       </WithListItem>

--- a/app/_customTypes/BlockContentTypes.ts
+++ b/app/_customTypes/BlockContentTypes.ts
@@ -7,11 +7,22 @@ export type Style =
   | "h6"
   | "blockquote"
   | "normal";
-export type Mark = "strong" | "em" | "underline" | "strike-through" | "code";
+export type Mark =
+  | "strong"
+  | "em"
+  | "underline"
+  | "strike-through"
+  | "code"
+  | string;
+export type MarkDef = {
+  _type: "link";
+  href: string;
+  _key: string;
+};
 type BlockBase = {
   _type: "block";
   _key?: string;
-  markDefs?: unknown[];
+  markDefs?: MarkDef[];
   style: Style;
   children: {
     _type?: "span";

--- a/stories/BlockContentItem.stories.tsx
+++ b/stories/BlockContentItem.stories.tsx
@@ -8,6 +8,7 @@ import {
   DUMMY_BLOCK_CONTENT_STRIKETHROUGH,
   DUMMY_BLOCK_CONTENT_STRONG_EM_UNDERLINE_STRIKETHROUGH,
   DUMMY_BLOCK_CONTENT_INLINE_CODE,
+  DUMMY_BLOCK_CONTENT_LINKS,
   DUMMY_BLOCK_CONTENT_WITH_CODE_BLOCK,
   DUMMY_BLOCK_CONTENT_WITH_BOTH_LISTS,
   DUMMY_BLOCK_CONTENT_WITH_LONG_BLOCKQUOTE_AND_CODE,
@@ -93,6 +94,12 @@ export const BlockStrongEmUnderlineStrikethrough: Story = {
 export const BlockInlineCode: Story = {
   render: () => {
     return <BlockContent blockContent={DUMMY_BLOCK_CONTENT_INLINE_CODE} />;
+  },
+};
+
+export const BlockLinks: Story = {
+  render: () => {
+    return <BlockContent blockContent={DUMMY_BLOCK_CONTENT_LINKS} />;
   },
 };
 

--- a/stories/dummyBlockContent.ts
+++ b/stories/dummyBlockContent.ts
@@ -336,8 +336,6 @@ export const DUMMY_BLOCK_CONTENT_WITH_BOTH_LISTS_AFTER_GROUPING: GroupedBlockCon
 
 export const DUMMY_BLOCK_CONTENT_COMPREHENSIVE: BlockContentItemData[] = [
   {
-    style: "h1",
-    _key: "e5c70833c225",
     markDefs: [],
     children: [
       {
@@ -348,15 +346,17 @@ export const DUMMY_BLOCK_CONTENT_COMPREHENSIVE: BlockContentItemData[] = [
       },
     ],
     _type: "block",
+    style: "h1",
+    _key: "e5c70833c225",
   },
   {
     markDefs: [],
     children: [
       {
+        _key: "53339e6c9a8f",
         _type: "span",
         marks: [],
         text: "Lorem ipsum oogum boogum. Tutant Meenage Neetle Teetles have been running amuck in the city of New York. How can we stop these mean green fighting machines?",
-        _key: "53339e6c9a8f",
       },
     ],
     _type: "block",
@@ -364,12 +364,58 @@ export const DUMMY_BLOCK_CONTENT_COMPREHENSIVE: BlockContentItemData[] = [
     _key: "ae1909e3a3a9",
   },
   {
+    _key: "c25f3ccd7470",
+    markDefs: [],
     children: [
       {
+        _key: "da1735693e18",
+        _type: "span",
+        marks: [],
+        text: "",
+      },
+    ],
+    _type: "block",
+    style: "normal",
+  },
+  {
+    markDefs: [
+      {
+        _key: "a4f4c719091e",
+        _type: "link",
+        href: "https://www.google.com",
+      },
+    ],
+    children: [
+      {
+        _type: "span",
+        marks: [],
+        text: "Here's a sentence with a ",
+        _key: "35cec051ad36",
+      },
+      {
+        _type: "span",
+        marks: ["a4f4c719091e"],
+        text: "link",
+        _key: "1679ff986468",
+      },
+      {
+        _type: "span",
+        marks: [],
+        text: " in it.",
+        _key: "4af22df23c1e",
+      },
+    ],
+    _type: "block",
+    style: "normal",
+    _key: "11f7ebf82080",
+  },
+  {
+    children: [
+      {
+        _type: "span",
         marks: [],
         text: "",
         _key: "2951d4e60fce",
-        _type: "span",
       },
     ],
     _type: "block",
@@ -383,15 +429,18 @@ export const DUMMY_BLOCK_CONTENT_COMPREHENSIVE: BlockContentItemData[] = [
     markDefs: [],
     children: [
       {
-        _key: "45364ca5dabb",
         _type: "span",
         marks: [],
         text: "Option 1.",
+        _key: "45364ca5dabb",
       },
     ],
     _type: "block",
   },
   {
+    _type: "block",
+    style: "normal",
+    _key: "454b339845c9",
     markDefs: [],
     children: [
       {
@@ -407,29 +456,26 @@ export const DUMMY_BLOCK_CONTENT_COMPREHENSIVE: BlockContentItemData[] = [
         _key: "d3daf799a4e2",
       },
       {
+        _key: "b94943abd8df",
         _type: "span",
         marks: ["em"],
         text: "This however, is italic, and must be fucked with.",
-        _key: "b94943abd8df",
       },
     ],
-    _type: "block",
-    style: "normal",
-    _key: "454b339845c9",
   },
   {
+    markDefs: [],
     children: [
       {
+        marks: [],
         text: "",
         _key: "2190dd2f36c9",
         _type: "span",
-        marks: [],
       },
     ],
     _type: "block",
     style: "normal",
     _key: "39b1676eb56f",
-    markDefs: [],
   },
   {
     _type: "block",
@@ -438,10 +484,10 @@ export const DUMMY_BLOCK_CONTENT_COMPREHENSIVE: BlockContentItemData[] = [
     markDefs: [],
     children: [
       {
+        marks: [],
         text: "Option deuce;",
         _key: "f0ede33c3355",
         _type: "span",
-        marks: [],
       },
     ],
   },
@@ -451,15 +497,17 @@ export const DUMMY_BLOCK_CONTENT_COMPREHENSIVE: BlockContentItemData[] = [
     markDefs: [],
     children: [
       {
+        _type: "span",
         marks: [],
         text: "Bribe with pizza in this three step plan:",
         _key: "aabd41d6b1a3",
-        _type: "span",
       },
     ],
     _type: "block",
   },
   {
+    level: 1,
+    _type: "block",
     style: "normal",
     _key: "73cabd734817",
     listItem: "number",
@@ -472,42 +520,41 @@ export const DUMMY_BLOCK_CONTENT_COMPREHENSIVE: BlockContentItemData[] = [
         _key: "80c56ac72085",
       },
     ],
-    level: 1,
-    _type: "block",
   },
   {
-    listItem: "number",
     markDefs: [],
     children: [
       {
-        _type: "span",
-        marks: [],
         text: "Throw it in the sewers",
         _key: "e27c5062bc57",
+        _type: "span",
+        marks: [],
       },
     ],
     level: 1,
     _type: "block",
     style: "normal",
     _key: "94e882640770",
+    listItem: "number",
   },
   {
-    children: [
-      {
-        _type: "span",
-        marks: ["strike-through"],
-        text: "Actually it's just a two step plan",
-        _key: "8e998ab9dd05",
-      },
-    ],
-    level: 1,
     _type: "block",
     style: "normal",
     _key: "86c491227b80",
     listItem: "number",
     markDefs: [],
+    children: [
+      {
+        text: "Actually it's just a two step plan",
+        _key: "8e998ab9dd05",
+        _type: "span",
+        marks: ["strike-through"],
+      },
+    ],
+    level: 1,
   },
   {
+    markDefs: [],
     children: [
       {
         _type: "span",
@@ -519,9 +566,11 @@ export const DUMMY_BLOCK_CONTENT_COMPREHENSIVE: BlockContentItemData[] = [
     _type: "block",
     style: "normal",
     _key: "b0a05125be9b",
-    markDefs: [],
   },
   {
+    _type: "block",
+    style: "h2",
+    _key: "e9151bbd80a2",
     markDefs: [],
     children: [
       {
@@ -531,21 +580,16 @@ export const DUMMY_BLOCK_CONTENT_COMPREHENSIVE: BlockContentItemData[] = [
         _key: "7afefc3f580d",
       },
     ],
-    _type: "block",
-    style: "h2",
-    _key: "e9151bbd80a2",
   },
   {
-    _type: "block",
-    style: "normal",
     _key: "b761fd874fe5",
     markDefs: [],
     children: [
       {
-        _key: "40c345d9b514",
         _type: "span",
         marks: [],
         text: "We write some ",
+        _key: "40c345d9b514",
       },
       {
         _type: "span",
@@ -554,40 +598,19 @@ export const DUMMY_BLOCK_CONTENT_COMPREHENSIVE: BlockContentItemData[] = [
         _key: "c0397323dcd6",
       },
       {
-        text: " to blow up their database:",
-        _key: "78d361eda04c",
         _type: "span",
         marks: [],
+        text: " to blow up their database:",
+        _key: "78d361eda04c",
       },
     ],
+    _type: "block",
+    style: "normal",
   },
   {
     language: "css",
     _key: "2d8920b95f83",
-    code: ".shredder {\n  display: flex;\n}",
+    code: "// Tutant meenage neetle teeeeetles tutant meenage neetle teeeetles Heroes in a half shell - Turtle Power!\n\n.shredder {\n  display: flex;\n}",
     _type: "code",
-  },
-  {
-    _type: "block",
-    style: "normal",
-    _key: "b761fd874fe5",
-    markDefs: [],
-    children: [
-      {
-        text: "",
-        _key: "78d361eda04c",
-        _type: "span",
-        marks: [],
-      },
-    ],
-  },
-  {
-    _key: "3657e4482fec",
-    _type: "image",
-    alt: "my-cool-alt-text",
-    asset: {
-      _ref: "image-e5270bee947b5a03a882f377730e52bcf4357ac0-1280x720-png",
-      _type: "reference",
-    },
   },
 ];

--- a/stories/dummyBlockContent.ts
+++ b/stories/dummyBlockContent.ts
@@ -1,6 +1,7 @@
 import {
   BlockContentItemData,
   Mark,
+  MarkDef,
   Style,
   GroupedBlockContent,
 } from "@customTypes/BlockContentTypes";
@@ -18,10 +19,11 @@ const STYLES = [
 
 const generateWithUniqueStyle = (
   style: Style,
-  marks: Mark[] = []
+  marks: Mark[] = [],
+  markDefs: MarkDef[] = []
 ): BlockContentItemData => ({
   _key: "123",
-  markDefs: [],
+  markDefs,
   children: [
     {
       _type: "span",
@@ -58,6 +60,14 @@ export const DUMMY_BLOCK_CONTENT_STRONG_EM_UNDERLINE_STRIKETHROUGH: BlockContent
   );
 export const DUMMY_BLOCK_CONTENT_INLINE_CODE: BlockContentItemData[] =
   STYLES.map((style) => generateWithUniqueStyle(style, ["code"]));
+export const DUMMY_BLOCK_CONTENT_LINKS: BlockContentItemData[] = STYLES.map(
+  (style, i) =>
+    generateWithUniqueStyle(
+      style,
+      [`123${i}`],
+      [{ _type: "link", href: "https://www.google.com", _key: `123${i}` }]
+    )
+);
 
 export const DUMMY_BLOCK_CONTENT_WITH_CODE_BLOCK: BlockContentItemData[] = [
   generateWithUniqueStyle("h2"),


### PR DESCRIPTION
Handles links coming from Sanity's `block` content.
Links open in a new page.

<img width="278" alt="image" src="https://github.com/user-attachments/assets/d49d2eef-dbbf-48e8-bfdd-32d3c0267899">

✅ Works inline
✅ Test coverage
✅ Storybook coverage

Also reworks the tests so that they assert the type of the wrapping element, not just its presence.
i.e, test that with `marks=["em"]`, the element found by the test id should be of `nodeName="EM"`