### PR TITLE
Extract WithStyle

### DIFF
--- a/app/_components/BlockItem.tsx
+++ b/app/_components/BlockItem.tsx
@@ -1,4 +1,4 @@
-import { Mark, MarkDef, Block } from "@customTypes/PortableTextTypes";
+import { Mark, MarkDef, Block, Style } from "@customTypes/PortableTextTypes";
 
 type WithListItemProps = {
   listItem: "bullet" | "number" | undefined;
@@ -9,6 +9,82 @@ const WithListItem = ({ listItem, children }: WithListItemProps) => {
     return <li data-testid="blockContent-li">{children}</li>;
   }
   return <div className="my-8">{children}</div>;
+};
+
+type WithStyleProps = {
+  style: Style;
+  children: React.ReactNode;
+};
+const WithStyle = ({ style, children }: WithStyleProps) => {
+  if (style === "normal")
+    return (
+      <p className="text-slate-900 inline" data-testid="blockContent-p">
+        {children}
+      </p>
+    );
+  if (style === "h1")
+    return (
+      <h1
+        className="text-30 text-slate-900 inline"
+        data-testid="blockContent-h1"
+      >
+        {children}
+      </h1>
+    );
+  if (style === "h2")
+    return (
+      <h2
+        className="text-24 text-slate-900 inline"
+        data-testid="blockContent-h2"
+      >
+        {children}
+      </h2>
+    );
+  if (style === "h3")
+    return (
+      <h3
+        className="text-20 text-slate-900 inline"
+        data-testid="blockContent-h3"
+      >
+        {children}
+      </h3>
+    );
+  if (style === "h4")
+    return (
+      <h4
+        className="text-18 text-slate-900 inline"
+        data-testid="blockContent-h4"
+      >
+        {children}
+      </h4>
+    );
+  if (style === "h5")
+    return (
+      <h5
+        className="text-16 text-slate-900 inline"
+        data-testid="blockContent-h5"
+      >
+        {children}
+      </h5>
+    );
+  if (style === "h6")
+    return (
+      <h6
+        className="text-14 text-slate-900 inline"
+        data-testid="blockContent-h6"
+      >
+        {children}
+      </h6>
+    );
+  if (style === "blockquote")
+    return (
+      <div
+        className="border-l-4 border-slate-900 bg-slate-400 p-8"
+        data-testid="blockContent-blockquote"
+      >
+        {children}
+      </div>
+    );
 };
 
 type WithMarksProps = {
@@ -69,90 +145,14 @@ export const BlockItem = ({ item }: BlockItemProps) => {
 
   return (
     <WithListItem listItem={listItem}>
-      {children.map((child, i) => {
-        if (child.text === "")
-          return <br key={i} data-testid="blockContent-br" />;
-        if (style === "normal")
-          return (
-            <p
-              key={i}
-              className="text-slate-900 inline"
-              data-testid="blockContent-p"
-            >
-              <WithMarks blockChild={child} markDefs={markDefs} />
-            </p>
-          );
-        if (style === "h1")
-          return (
-            <h1
-              className="text-30 text-slate-900 inline"
-              key={i}
-              data-testid="blockContent-h1"
-            >
-              <WithMarks blockChild={child} markDefs={markDefs} />
-            </h1>
-          );
-        if (style === "h2")
-          return (
-            <h2
-              className="text-24 text-slate-900 inline"
-              key={i}
-              data-testid="blockContent-h2"
-            >
-              <WithMarks blockChild={child} markDefs={markDefs} />
-            </h2>
-          );
-        if (style === "h3")
-          return (
-            <h3
-              className="text-20 text-slate-900 inline"
-              key={i}
-              data-testid="blockContent-h3"
-            >
-              <WithMarks blockChild={child} markDefs={markDefs} />
-            </h3>
-          );
-        if (style === "h4")
-          return (
-            <h4
-              className="text-18 text-slate-900 inline"
-              key={i}
-              data-testid="blockContent-h4"
-            >
-              <WithMarks blockChild={child} markDefs={markDefs} />
-            </h4>
-          );
-        if (style === "h5")
-          return (
-            <h5
-              className="text-16 text-slate-900 inline"
-              key={i}
-              data-testid="blockContent-h5"
-            >
-              <WithMarks blockChild={child} markDefs={markDefs} />
-            </h5>
-          );
-        if (style === "h6")
-          return (
-            <h6
-              className="text-14 text-slate-900 inline"
-              key={i}
-              data-testid="blockContent-h6"
-            >
-              <WithMarks blockChild={child} markDefs={markDefs} />
-            </h6>
-          );
-        if (style === "blockquote")
-          return (
-            <div
-              className="border-l-4 border-slate-900 bg-slate-400 p-8"
-              data-testid="blockContent-blockquote"
-              key={i}
-            >
-              <WithMarks blockChild={child} key={i} markDefs={markDefs} />
-            </div>
-          );
-      })}
+      <WithStyle style={style}>
+        {children.map((child, i) => {
+          if (child.text === "")
+            return <br key={i} data-testid="blockContent-br" />;
+
+          return <WithMarks key={i} blockChild={child} markDefs={markDefs} />;
+        })}
+      </WithStyle>
     </WithListItem>
   );
 };

--- a/app/_components/PortableTextItem.tsx
+++ b/app/_components/PortableTextItem.tsx
@@ -2,11 +2,7 @@ import React from "react";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import { tomorrowNightBright } from "react-syntax-highlighter/dist/esm/styles/hljs";
 
-import {
-  PortableTextItem as PortableTextItemType,
-  Mark,
-  MarkDef,
-} from "@customTypes/PortableTextTypes";
+import { PortableTextItem as PortableTextItemType } from "@customTypes/PortableTextTypes";
 import { ArticleImage } from "@components/ArticleImage";
 import { BlockItem } from "@components/BlockItem";
 


### PR DESCRIPTION
This PR is also for readability. It extracts the `_style` logic into a HOC called `<WithStyle/>`. This makes the hierarchy of tags much easier to understand when looking at the `render` function:
```tsx
render(
    <WithListItem>
        <WithStyle>
            <WithMarks>
                 {children.map(...)}
            </WithMarks>
        </WithStyle>
    </WithListItem>
)
```
It also cuts down on the amount of `style` based tags (`<p>`, `<h1>` etc.)