### PR TITLE
Clean styles

### DIFF
--- a/app/_components/BlockItem.tsx
+++ b/app/_components/BlockItem.tsx
@@ -18,61 +18,43 @@ type WithStyleProps = {
 const WithStyle = ({ style, children }: WithStyleProps) => {
   if (style === "normal")
     return (
-      <p className="text-slate-900 inline" data-testid="blockContent-p">
+      <p className="text-slate-900" data-testid="blockContent-p">
         {children}
       </p>
     );
   if (style === "h1")
     return (
-      <h1
-        className="text-30 text-slate-900 inline"
-        data-testid="blockContent-h1"
-      >
+      <h1 className="text-30 text-slate-900" data-testid="blockContent-h1">
         {children}
       </h1>
     );
   if (style === "h2")
     return (
-      <h2
-        className="text-24 text-slate-900 inline"
-        data-testid="blockContent-h2"
-      >
+      <h2 className="text-24 text-slate-900" data-testid="blockContent-h2">
         {children}
       </h2>
     );
   if (style === "h3")
     return (
-      <h3
-        className="text-20 text-slate-900 inline"
-        data-testid="blockContent-h3"
-      >
+      <h3 className="text-20 text-slate-900" data-testid="blockContent-h3">
         {children}
       </h3>
     );
   if (style === "h4")
     return (
-      <h4
-        className="text-18 text-slate-900 inline"
-        data-testid="blockContent-h4"
-      >
+      <h4 className="text-18 text-slate-900" data-testid="blockContent-h4">
         {children}
       </h4>
     );
   if (style === "h5")
     return (
-      <h5
-        className="text-16 text-slate-900 inline"
-        data-testid="blockContent-h5"
-      >
+      <h5 className="text-16 text-slate-900" data-testid="blockContent-h5">
         {children}
       </h5>
     );
   if (style === "h6")
     return (
-      <h6
-        className="text-14 text-slate-900 inline"
-        data-testid="blockContent-h6"
-      >
+      <h6 className="text-14 text-slate-900" data-testid="blockContent-h6">
         {children}
       </h6>
     );

--- a/stories/dummyBlockContent.ts
+++ b/stories/dummyBlockContent.ts
@@ -20,66 +20,77 @@ const STYLES = [
 const generateWithUniqueStyle = (
   style: Style,
   marks: Mark[] = [],
+  markDefs: MarkDef[] = [],
+  listItem: "bullet" | "number" | undefined = undefined
+): PortableTextItem => {
+  const listItemFields = listItem ? { listItem, level: 1 } : {};
+  return {
+    _key: "123",
+    markDefs,
+    children: [
+      {
+        _type: "span",
+        marks,
+        text: `This is a ${style} tag`,
+        _key: "123",
+      },
+    ],
+    _type: "block",
+    ...listItemFields,
+    style,
+  };
+};
+const generateAllStylesWithAllListTypes = (
+  marks: Mark[] = [],
   markDefs: MarkDef[] = []
-): PortableTextItem => ({
-  _key: "123",
-  markDefs,
-  children: [
-    {
-      _type: "span",
-      marks,
-      text: `This is a ${style} tag`,
-      _key: "123",
-    },
-  ],
-  _type: "block",
-  style,
-});
-export const DUMMY_BLOCK_CONTENT_NO_MARKS: PortableTextItem[] = STYLES.map(
-  (style) => generateWithUniqueStyle(style)
-);
-export const DUMMY_BLOCK_CONTENT_STRONG: PortableTextItem[] = STYLES.map(
-  (style) => generateWithUniqueStyle(style, ["strong"])
-);
-export const DUMMY_BLOCK_CONTENT_EM: PortableTextItem[] = STYLES.map((style) =>
-  generateWithUniqueStyle(style, ["em"])
-);
-export const DUMMY_BLOCK_CONTENT_UNDERLINE: PortableTextItem[] = STYLES.map(
-  (style) => generateWithUniqueStyle(style, ["underline"])
-);
-export const DUMMY_BLOCK_CONTENT_STRIKETHROUGH: PortableTextItem[] = STYLES.map(
-  (style) => generateWithUniqueStyle(style, ["strike-through"])
-);
-export const DUMMY_BLOCK_CONTENT_STRONG_EM_UNDERLINE_STRIKETHROUGH: PortableTextItem[] =
-  STYLES.map((style) =>
-    generateWithUniqueStyle(style, [
-      "strong",
-      "em",
-      "underline",
-      "strike-through",
-    ])
+) => {
+  const allStylesNoList = STYLES.map((style) =>
+    generateWithUniqueStyle(style, marks, markDefs)
   );
-export const DUMMY_BLOCK_CONTENT_INLINE_CODE: PortableTextItem[] = STYLES.map(
-  (style) => generateWithUniqueStyle(style, ["code"])
-);
-export const DUMMY_BLOCK_CONTENT_LINKS: PortableTextItem[] = STYLES.map(
-  (style, i) =>
-    generateWithUniqueStyle(
-      style,
-      [`123${i}`],
-      [{ _type: "link", href: "https://www.google.com", _key: `123${i}` }]
-    )
-);
+  const allStylesWithNumberedList = STYLES.map((style) =>
+    generateWithUniqueStyle(style, marks, markDefs, "number")
+  );
+  const allStylesWithBulletList = STYLES.map((style) =>
+    generateWithUniqueStyle(style, marks, markDefs, "bullet")
+  );
+  return [
+    ...allStylesNoList,
+    ...allStylesWithNumberedList,
+    ...allStylesWithBulletList,
+  ];
+};
+export const DUMMY_BLOCK_CONTENT_NO_MARKS: PortableTextItem[] =
+  generateAllStylesWithAllListTypes();
+export const DUMMY_BLOCK_CONTENT_STRONG: PortableTextItem[] =
+  generateAllStylesWithAllListTypes(["strong"]);
+export const DUMMY_BLOCK_CONTENT_EM: PortableTextItem[] =
+  generateAllStylesWithAllListTypes(["em"]);
+export const DUMMY_BLOCK_CONTENT_UNDERLINE: PortableTextItem[] =
+  generateAllStylesWithAllListTypes(["underline"]);
+export const DUMMY_BLOCK_CONTENT_STRIKETHROUGH: PortableTextItem[] =
+  generateAllStylesWithAllListTypes(["strike-through"]);
+export const DUMMY_BLOCK_CONTENT_STRONG_EM_UNDERLINE_STRIKETHROUGH: PortableTextItem[] =
+  generateAllStylesWithAllListTypes([
+    "strong",
+    "em",
+    "underline",
+    "strike-through",
+  ]);
+export const DUMMY_BLOCK_CONTENT_INLINE_CODE: PortableTextItem[] =
+  generateAllStylesWithAllListTypes(["code"]);
+export const DUMMY_BLOCK_CONTENT_LINKS: PortableTextItem[] =
+  generateAllStylesWithAllListTypes(
+    ["123"],
+    [{ _type: "link", href: "https://www.google.com", _key: "123" }]
+  );
 
 export const DUMMY_BLOCK_CONTENT_WITH_CODE_BLOCK: PortableTextItem[] = [
-  generateWithUniqueStyle("h2"),
   {
     _type: "code",
     _key: "123",
     code: `// This is a TS code block\n\nconst foo = "bar"\nconst myObj {\n  foo: "bar"\n}\n"Will this be delineated?"`,
     language: "typescript",
   },
-  generateWithUniqueStyle("normal"),
 ];
 
 export const DUMMY_BLOCK_CONTENT_WITH_LONG_BLOCKQUOTE_AND_CODE: PortableTextItem[] =


### PR DESCRIPTION
Removes some unneeded styles, and also takes the opportunity to improve the Storybook coverage by adding full ordered and unordered list examples to each `style` story (`h1`, `h2` etc.)