### PR TITLE
Rename to generatePortableTextItem

### DIFF
--- a/stories/PortableTextConverter.stories.tsx
+++ b/stories/PortableTextConverter.stories.tsx
@@ -52,99 +52,42 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const BlockNoMarks: Story = {
-  render: () => {
-    return (
-      <PortableTextConverter portableText={DUMMY_BLOCK_CONTENT_NO_MARKS} />
-    );
-  },
+  args: { portableText: DUMMY_BLOCK_CONTENT_NO_MARKS },
 };
-
 export const BlockStrong: Story = {
-  render: () => {
-    return <PortableTextConverter portableText={DUMMY_BLOCK_CONTENT_STRONG} />;
-  },
+  args: { portableText: DUMMY_BLOCK_CONTENT_STRONG },
 };
-
 export const BlockEm: Story = {
-  render: () => {
-    return <PortableTextConverter portableText={DUMMY_BLOCK_CONTENT_EM} />;
-  },
+  args: { portableText: DUMMY_BLOCK_CONTENT_EM },
 };
-
 export const BlockUnderline: Story = {
-  render: () => {
-    return (
-      <PortableTextConverter portableText={DUMMY_BLOCK_CONTENT_UNDERLINE} />
-    );
-  },
+  args: { portableText: DUMMY_BLOCK_CONTENT_UNDERLINE },
 };
-
 export const BlockStrikethrough: Story = {
-  render: () => {
-    return (
-      <PortableTextConverter portableText={DUMMY_BLOCK_CONTENT_STRIKETHROUGH} />
-    );
-  },
+  args: { portableText: DUMMY_BLOCK_CONTENT_STRIKETHROUGH },
 };
-
 export const BlockStrongEmUnderlineStrikethrough: Story = {
-  render: () => {
-    return (
-      <PortableTextConverter
-        portableText={DUMMY_BLOCK_CONTENT_STRONG_EM_UNDERLINE_STRIKETHROUGH}
-      />
-    );
-  },
+  args: { portableText: DUMMY_BLOCK_CONTENT_STRONG_EM_UNDERLINE_STRIKETHROUGH },
 };
-
 export const BlockInlineCode: Story = {
-  render: () => {
-    return (
-      <PortableTextConverter portableText={DUMMY_BLOCK_CONTENT_INLINE_CODE} />
-    );
-  },
+  args: { portableText: DUMMY_BLOCK_CONTENT_INLINE_CODE },
 };
-
 export const BlockLinks: Story = {
-  render: () => {
-    return <PortableTextConverter portableText={DUMMY_BLOCK_CONTENT_LINKS} />;
-  },
+  args: { portableText: DUMMY_BLOCK_CONTENT_LINKS },
 };
 
 export const WithLongBlockQuote: Story = {
-  render: () => {
-    return (
-      <PortableTextConverter
-        portableText={DUMMY_BLOCK_CONTENT_WITH_LONG_BLOCKQUOTE_AND_CODE}
-      />
-    );
-  },
+  args: { portableText: DUMMY_BLOCK_CONTENT_WITH_LONG_BLOCKQUOTE_AND_CODE },
 };
 
 export const WithLists: Story = {
-  render: () => {
-    return (
-      <PortableTextConverter
-        portableText={DUMMY_BLOCK_CONTENT_WITH_BOTH_LISTS}
-      />
-    );
-  },
+  args: { portableText: DUMMY_BLOCK_CONTENT_WITH_BOTH_LISTS },
 };
 
 export const WithCodeBlockPlugin: Story = {
-  render: () => {
-    return (
-      <PortableTextConverter
-        portableText={DUMMY_BLOCK_CONTENT_WITH_CODE_BLOCK}
-      />
-    );
-  },
+  args: { portableText: DUMMY_BLOCK_CONTENT_WITH_CODE_BLOCK },
 };
 
 export const WithComprehensiveData: Story = {
-  render: () => {
-    return (
-      <PortableTextConverter portableText={DUMMY_BLOCK_CONTENT_COMPREHENSIVE} />
-    );
-  },
+  args: { portableText: DUMMY_BLOCK_CONTENT_COMPREHENSIVE },
 };

--- a/stories/dummyBlockContent.ts
+++ b/stories/dummyBlockContent.ts
@@ -17,7 +17,7 @@ const STYLES = [
   "blockquote",
 ] as const;
 
-const generateWithUniqueStyle = (
+const generatePortableTextItem = (
   style: Style,
   marks: Mark[] = [],
   markDefs: MarkDef[] = [],
@@ -44,21 +44,27 @@ const generateAllStylesWithAllListTypes = (
   marks: Mark[] = [],
   markDefs: MarkDef[] = []
 ) => {
-  const allStylesNoList = STYLES.map((style) =>
-    generateWithUniqueStyle(style, marks, markDefs)
-  );
-  const allStylesWithNumberedList = STYLES.map((style) =>
-    generateWithUniqueStyle(style, marks, markDefs, "number")
-  );
-  const allStylesWithBulletList = STYLES.map((style) =>
-    generateWithUniqueStyle(style, marks, markDefs, "bullet")
-  );
+  const allStylesNoList: PortableTextItem[] = [];
+  const allStylesWithNumberedList: PortableTextItem[] = [];
+  const allStylesWithBulletList: PortableTextItem[] = [];
+
+  STYLES.forEach((style) => {
+    allStylesNoList.push(generatePortableTextItem(style, marks, markDefs));
+    allStylesWithNumberedList.push(
+      generatePortableTextItem(style, marks, markDefs, "number")
+    );
+    allStylesWithBulletList.push(
+      generatePortableTextItem(style, marks, markDefs, "bullet")
+    );
+  });
+
   return [
     ...allStylesNoList,
     ...allStylesWithNumberedList,
     ...allStylesWithBulletList,
   ];
 };
+
 export const DUMMY_BLOCK_CONTENT_NO_MARKS: PortableTextItem[] =
   generateAllStylesWithAllListTypes();
 export const DUMMY_BLOCK_CONTENT_STRONG: PortableTextItem[] =
@@ -188,23 +194,23 @@ const ul2_2: PortableTextItem = {
   ],
 };
 export const DUMMY_BLOCK_CONTENT_WITH_UNORDERED_LIST: PortableTextItem[] = [
-  generateWithUniqueStyle("h2"),
+  generatePortableTextItem("h2"),
   ul1_1,
   ul2_1,
-  generateWithUniqueStyle("h3"),
+  generatePortableTextItem("h3"),
   ul1_2,
   ul2_2,
 ];
 export const DUMMY_BLOCK_CONTENT_WITH_UNORDERED_LIST_AFTER_GROUPING: PortableTextWithListItemsGrouped =
   [
-    generateWithUniqueStyle("h2"),
+    generatePortableTextItem("h2"),
     {
       _type: "groupedListItems",
       listItem: "bullet",
       blockContent: [ul1_1, ul2_1],
       level: 1,
     },
-    generateWithUniqueStyle("h3"),
+    generatePortableTextItem("h3"),
     {
       _type: "groupedListItems",
       listItem: "bullet",
@@ -278,24 +284,24 @@ const ol2_2: PortableTextItem = {
   ],
 };
 export const DUMMY_BLOCK_CONTENT_WITH_ORDERED_LIST: PortableTextItem[] = [
-  generateWithUniqueStyle("h2"),
+  generatePortableTextItem("h2"),
   ol1_1,
   ol2_1,
-  generateWithUniqueStyle("h3"),
+  generatePortableTextItem("h3"),
   ol1_2,
   ol2_2,
 ];
 
 export const DUMMY_BLOCK_CONTENT_WITH_ORDERED_LIST_AFTER_GROUPING: PortableTextWithListItemsGrouped =
   [
-    generateWithUniqueStyle("h2"),
+    generatePortableTextItem("h2"),
     {
       _type: "groupedListItems",
       listItem: "number",
       blockContent: [ol1_1, ol2_1],
       level: 1,
     },
-    generateWithUniqueStyle("h3"),
+    generatePortableTextItem("h3"),
     {
       _type: "groupedListItems",
       listItem: "number",
@@ -305,12 +311,12 @@ export const DUMMY_BLOCK_CONTENT_WITH_ORDERED_LIST_AFTER_GROUPING: PortableTextW
   ];
 
 export const DUMMY_BLOCK_CONTENT_WITH_BOTH_LISTS: PortableTextItem[] = [
-  generateWithUniqueStyle("h2"),
+  generatePortableTextItem("h2"),
   ol1_1,
   ol2_1,
   ol1_2,
   ol2_2,
-  generateWithUniqueStyle("h3"),
+  generatePortableTextItem("h3"),
   ul1_1,
   ul2_1,
   ul1_2,
@@ -319,7 +325,7 @@ export const DUMMY_BLOCK_CONTENT_WITH_BOTH_LISTS: PortableTextItem[] = [
 
 export const DUMMY_BLOCK_CONTENT_WITH_BOTH_LISTS_AFTER_GROUPING: PortableTextWithListItemsGrouped =
   [
-    generateWithUniqueStyle("h2"),
+    generatePortableTextItem("h2"),
     {
       _type: "groupedListItems",
       listItem: "number",
@@ -332,7 +338,7 @@ export const DUMMY_BLOCK_CONTENT_WITH_BOTH_LISTS_AFTER_GROUPING: PortableTextWit
       blockContent: [ol1_2, ol2_2],
       level: 2,
     },
-    generateWithUniqueStyle("h3"),
+    generatePortableTextItem("h3"),
     {
       _type: "groupedListItems",
       listItem: "bullet",


### PR DESCRIPTION
Renames `generateWithUniqueStyle` to `generatePortableTextItem`. This is a better name now that `marks`, `markDefs`, and `listItem` args can also be passed, instead of just `style`