### PR TITLE
Refactor tests

### DIFF
--- a/__tests__/PortableTextItem.test.tsx
+++ b/__tests__/PortableTextItem.test.tsx
@@ -190,11 +190,10 @@ describe("_type = block", () => {
     };
 
     it("Renders a <br> tag", () => {
-      render(<PortableTextItem item={withEmptyText} />);
+      const { container } = render(<PortableTextItem item={withEmptyText} />);
+      const brTag = container.querySelector("br");
 
-      const element = screen.getByTestId("blockContent-br");
-
-      expect(element.nodeName).toBe("BR");
+      expect(brTag).toBeTruthy();
     });
   });
 

--- a/__tests__/PortableTextItem.test.tsx
+++ b/__tests__/PortableTextItem.test.tsx
@@ -148,6 +148,35 @@ const testWithStyles = (listItem: "bullet" | "number" | undefined) => {
   });
 };
 
+const listItemsToTest = [
+  { listItem: "bullet", selector: "li" },
+  { listItem: "number", selector: "li" },
+  { listItem: undefined, selector: "[data-testId='blockContentDivWrapper']" },
+] as const;
+
+const testWithListItems = () => {
+  listItemsToTest.forEach(({ listItem, selector }) => {
+    describe(`When listItem = '${listItem}'`, () => {
+      it(`Renders content inside an <${selector}> tag`, () => {
+        const portableTextItem = generatePortableTextItem(
+          "normal",
+          [],
+          [],
+          listItem
+        );
+        const { container } = render(
+          <PortableTextItem item={portableTextItem} />
+        );
+        const tag = container?.querySelector(selector);
+
+        expect(tag).toBeTruthy();
+      });
+
+      testWithStyles(listItem);
+    });
+  });
+};
+
 describe("_type = image", () => {
   const withImage: PortableTextItemType = {
     _key: "3657e4482fec",
@@ -197,13 +226,5 @@ describe("_type = block", () => {
     });
   });
 
-  describe("With no list styles", () => {
-    testWithStyles(undefined);
-  });
-  describe("With bullet list styles", () => {
-    testWithStyles("bullet");
-  });
-  describe("With numbered list styles", () => {
-    testWithStyles("number");
-  });
+  testWithListItems();
 });

--- a/__tests__/PortableTextItem.test.tsx
+++ b/__tests__/PortableTextItem.test.tsx
@@ -2,7 +2,7 @@ import "@testing-library/jest-dom";
 import { screen, render, within } from "@testing-library/react";
 import NextImage from "next/image";
 
-import { generatePortableTextItem } from "@/stories/dummyBlockContent";
+import { generatePortableTextItem, STYLES } from "@/stories/dummyBlockContent";
 import { PortableTextItem } from "@components/PortableTextItem";
 import {
   PortableTextItem as PortableTextItemType,
@@ -20,452 +20,499 @@ jest.mock("../sanity/client", () => ({
   urlFor: (url: string) => ({ url: () => url }),
 }));
 
-const TestWithListItem = (
-  style: Style,
-  testId: string,
-  listItem: "bullet" | "number"
-) => {
-  const props: PortableTextItemType = {
-    _type: "block",
-    _key: "123",
-    style: style,
-    markDefs: [],
-    children: [
-      {
-        _key: "123",
-        _type: "span",
-        text: "Hello",
-        marks: [],
-      },
-    ],
-    listItem,
-    level: 1,
-  };
+const testWithStyles = (listItem: "bullet" | "number" | undefined) => {
+  STYLES.forEach((style) => {
+    let tag: string = style;
+    if (style === "normal") {
+      tag = "p";
+    }
+    if (style === "blockquote") {
+      tag = "div";
+    }
 
-  describe("listItem = 'bullet' | 'number'", () => {
-    it("Renders text content in a <li> tag within element", () => {
-      render(<PortableTextItem item={props} />);
-
-      const li = screen.getByTestId("blockContent-li");
-      const element = within(li).getByTestId(testId);
-
-      expect(li.nodeName).toBe("LI");
-      expect(element).toBeInTheDocument();
-    });
-
-    TestWithMarks(style, "blockContent-li", "bullet");
-  });
-};
-
-const TestWithMarks = (
-  style: Style,
-  testId: string,
-  listItem?: "bullet" | "number"
-) => {
-  describe("marks includes 'em'", () => {
-    it("Wraps contents of element in <em>", () => {
-      const blockContent: PortableTextItemType = generatePortableTextItem(
-        style,
-        ["em"],
-        [],
-        listItem
-      );
-      render(<PortableTextItem item={blockContent} />);
-
-      const element = screen.getByTestId(testId);
-      const em = within(element).getByTestId("blockContent-em");
-
-      expect(em.nodeName).toBe("EM");
-    });
-  });
-  describe("marks includes 'strong'", () => {
-    it("Wraps contents of element in <strong>", () => {
-      const blockContent: PortableTextItemType = generatePortableTextItem(
-        style,
-        ["strong"],
-        [],
-        listItem
-      );
-      render(<PortableTextItem item={blockContent} />);
-
-      const element = screen.getByTestId(testId);
-      const strong = within(element).getByTestId("blockContent-strong");
-
-      expect(strong.nodeName).toBe("STRONG");
-    });
-  });
-  describe("marks includes 'underline'", () => {
-    it("Wraps contents of element in <u>", () => {
-      const blockContent: PortableTextItemType = generatePortableTextItem(
-        style,
-        ["underline"],
-        [],
-        listItem
-      );
-      render(<PortableTextItem item={blockContent} />);
-
-      const element = screen.getByTestId(testId);
-      const underline = within(element).getByTestId("blockContent-u");
-
-      expect(underline.nodeName).toBe("U");
-    });
-  });
-  describe("marks includes 'strikethrough'", () => {
-    it("Wraps contents of element in <s>", () => {
-      const blockContent: PortableTextItemType = generatePortableTextItem(
-        style,
-        ["strike-through"],
-        [],
-        listItem
-      );
-      render(<PortableTextItem item={blockContent} />);
-
-      const element = screen.getByTestId(testId);
-      const strikethrough = within(element).getByTestId("blockContent-s");
-
-      expect(strikethrough.nodeName).toBe("S");
-    });
-  });
-  describe("marks includes 'code'", () => {
-    it("Wraps contents of element in <code>", () => {
-      const blockContent: PortableTextItemType = generatePortableTextItem(
-        style,
-        ["code"],
-        [],
-        listItem
-      );
-      render(<PortableTextItem item={blockContent} />);
-
-      const element = screen.getByTestId(testId);
-      const code = within(element).getByTestId("blockContent-code");
-
-      expect(code).toBeInTheDocument();
-    });
-  });
-  describe("marks includes a non-standard string", () => {
-    describe("mark references a markDef of _type='link'", () => {
-      it("Wraps contents of element in <a>", () => {
-        const blockContent: PortableTextItemType = generatePortableTextItem(
+    describe(`and style = ${style}`, () => {
+      it(`Renders in a <${tag}> tag`, () => {
+        const portableTextItem = generatePortableTextItem(
           style,
-          ["123"],
-          [{ _type: "link", href: "https://example.com", _key: "123" }],
+          [],
+          [],
           listItem
         );
-        render(<PortableTextItem item={blockContent} />);
 
-        const element = screen.getByTestId(testId);
-        const a = within(element).getByTestId("blockContent-a");
+        const { container } = render(
+          <PortableTextItem item={portableTextItem} />
+        );
+        const parentElement = listItem
+          ? container.querySelector("li")
+          : container.querySelector("[data-testId='blockContentDivWrapper']");
 
-        expect(a.nodeName).toBe("A");
+        const styleElement = parentElement?.querySelector(tag);
+        if (!styleElement) {
+          console.log(tag);
+        }
+
+        expect(styleElement).toBeTruthy();
       });
     });
   });
-  describe("marks include 'strong', 'em', 'underline', 'strikethrough' and 'code'", () => {
-    it("Wraps contents of element in <strong>, <em>, <underline>, <s> and <code>", () => {
-      const blockContent: PortableTextItemType = generatePortableTextItem(
-        style,
-        ["strong", "em", "underline", "strike-through", "code"],
-        [],
-        listItem
-      );
-      render(<PortableTextItem item={blockContent} />);
-
-      const element = screen.getByTestId(testId);
-      const strong = within(element).getByTestId("blockContent-strong");
-      const em = within(element).getByTestId("blockContent-em");
-      const u = within(element).getByTestId("blockContent-u");
-      const s = within(element).getByTestId("blockContent-s");
-      const code = within(element).getByTestId("blockContent-code");
-
-      expect(strong.nodeName).toBe("STRONG");
-      expect(em.nodeName).toBe("EM");
-      expect(u.nodeName).toBe("U");
-      expect(s.nodeName).toBe("S");
-      expect(code).toBeInTheDocument();
-    });
-  });
 };
 
-describe("_type = image", () => {
-  const withImage: PortableTextItemType = {
-    _key: "3657e4482fec",
-    _type: "image",
-    alt: "my-cool-alt-text",
-    asset: {
-      _ref: "image-e5270bee947b5a03a882f377730e52bcf4357ac0-1280x720-png",
-      _type: "reference",
-    },
-  };
-
-  it("Renders the image", () => {
-    render(<PortableTextItem item={withImage} />);
-
-    expect(NextImage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        src: withImage.asset._ref,
-        alt: withImage.alt,
-      }),
-      {}
-    );
-  });
+describe("With no list styles", () => {
+  testWithStyles(undefined);
+});
+describe("With bullet list styles", () => {
+  testWithStyles("bullet");
+});
+describe("With numbered list styles", () => {
+  testWithStyles("number");
 });
 
-describe("_type = block", () => {
-  describe("text is empty", () => {
-    const withEmptyText: PortableTextItemType = {
-      _type: "block",
-      _key: "123",
-      markDefs: [],
-      style: "normal",
-      children: [
-        {
-          _key: "123",
-          _type: "span",
-          text: "",
-          marks: [],
-        },
-      ],
-    };
+// const TestWithListItem = (
+//   style: Style,
+//   testId: string,
+//   listItem: "bullet" | "number"
+// ) => {
+//   const props: PortableTextItemType = {
+//     _type: "block",
+//     _key: "123",
+//     style: style,
+//     markDefs: [],
+//     children: [
+//       {
+//         _key: "123",
+//         _type: "span",
+//         text: "Hello",
+//         marks: [],
+//       },
+//     ],
+//     listItem,
+//     level: 1,
+//   };
 
-    it("Renders a <br> tag", () => {
-      render(<PortableTextItem item={withEmptyText} />);
+//   describe("listItem = 'bullet' | 'number'", () => {
+//     it("Renders text content in a <li> tag within element", () => {
+//       render(<PortableTextItem item={props} />);
 
-      const element = screen.getByTestId("blockContent-br");
+//       const li = screen.getByTestId("blockContent-li");
+//       const element = within(li).getByTestId(testId);
 
-      expect(element.nodeName).toBe("BR");
-    });
-  });
-  describe("style = normal", () => {
-    const style = "normal"; // <p>
-    it("Renders in a <p> tag", () => {
-      const blockContent: PortableTextItemType = {
-        _type: "block",
-        _key: "123",
-        markDefs: [],
-        style: style,
-        children: [
-          {
-            _key: "123",
-            _type: "span",
-            text: "Hello",
-            marks: [],
-          },
-        ],
-      };
-      render(<PortableTextItem item={blockContent} />);
+//       expect(li.nodeName).toBe("LI");
+//       expect(element).toBeInTheDocument();
+//     });
 
-      const element = screen.getByTestId("blockContent-p");
+//     TestWithMarks(style, "blockContent-li", "bullet");
+//   });
+// };
 
-      expect(element.nodeName).toBe("P");
-    });
+// const TestWithMarks = (
+//   style: Style,
+//   testId: string,
+//   listItem?: "bullet" | "number"
+// ) => {
+//   describe("marks includes 'em'", () => {
+//     it("Wraps contents of element in <em>", () => {
+//       const blockContent: PortableTextItemType = generatePortableTextItem(
+//         style,
+//         ["em"],
+//         [],
+//         listItem
+//       );
+//       render(<PortableTextItem item={blockContent} />);
 
-    TestWithMarks(style, "blockContent-p");
-    TestWithListItem(style, "blockContent-p", "bullet");
-    TestWithListItem(style, "blockContent-p", "number");
-  });
+//       const element = screen.getByTestId(testId);
+//       const em = within(element).getByTestId("blockContent-em");
 
-  describe("style = blockquote", () => {
-    const style = "blockquote"; // <p>
-    it("Renders in a <p> tag with blockquote styling", () => {
-      const blockContent: PortableTextItemType = {
-        _type: "block",
-        _key: "123",
-        markDefs: [],
-        style: style,
-        children: [
-          {
-            _key: "123",
-            _type: "span",
-            text: "Hello",
-            marks: [],
-          },
-        ],
-      };
-      render(<PortableTextItem item={blockContent} />);
+//       expect(em.nodeName).toBe("EM");
+//     });
+//   });
+//   describe("marks includes 'strong'", () => {
+//     it("Wraps contents of element in <strong>", () => {
+//       const blockContent: PortableTextItemType = generatePortableTextItem(
+//         style,
+//         ["strong"],
+//         [],
+//         listItem
+//       );
+//       render(<PortableTextItem item={blockContent} />);
 
-      const element = screen.getByTestId("blockContent-blockquote");
+//       const element = screen.getByTestId(testId);
+//       const strong = within(element).getByTestId("blockContent-strong");
 
-      expect(element.nodeName).toBe("DIV");
-      expect(element.classList.contains("border-l-4")).toBe(true);
-      expect(element.classList.contains("bg-slate-400")).toBe(true);
-    });
+//       expect(strong.nodeName).toBe("STRONG");
+//     });
+//   });
+//   describe("marks includes 'underline'", () => {
+//     it("Wraps contents of element in <u>", () => {
+//       const blockContent: PortableTextItemType = generatePortableTextItem(
+//         style,
+//         ["underline"],
+//         [],
+//         listItem
+//       );
+//       render(<PortableTextItem item={blockContent} />);
 
-    TestWithMarks(style, "blockContent-blockquote");
-    TestWithListItem(style, "blockContent-blockquote", "bullet");
-    TestWithListItem(style, "blockContent-blockquote", "number");
-  });
+//       const element = screen.getByTestId(testId);
+//       const underline = within(element).getByTestId("blockContent-u");
 
-  describe("style = h1", () => {
-    const style = "h1";
-    it("Renders in a <h1> tag", () => {
-      const blockContent: PortableTextItemType = {
-        _type: "block",
-        _key: "123",
-        markDefs: [],
-        style: style,
-        children: [
-          {
-            _key: "123",
-            _type: "span",
-            text: "Hello",
-            marks: [],
-          },
-        ],
-      };
-      render(<PortableTextItem item={blockContent} />);
+//       expect(underline.nodeName).toBe("U");
+//     });
+//   });
+//   describe("marks includes 'strikethrough'", () => {
+//     it("Wraps contents of element in <s>", () => {
+//       const blockContent: PortableTextItemType = generatePortableTextItem(
+//         style,
+//         ["strike-through"],
+//         [],
+//         listItem
+//       );
+//       render(<PortableTextItem item={blockContent} />);
 
-      const element = screen.getByTestId("blockContent-h1");
+//       const element = screen.getByTestId(testId);
+//       const strikethrough = within(element).getByTestId("blockContent-s");
 
-      expect(element.nodeName).toBe("H1");
-    });
+//       expect(strikethrough.nodeName).toBe("S");
+//     });
+//   });
+//   describe("marks includes 'code'", () => {
+//     it("Wraps contents of element in <code>", () => {
+//       const blockContent: PortableTextItemType = generatePortableTextItem(
+//         style,
+//         ["code"],
+//         [],
+//         listItem
+//       );
+//       render(<PortableTextItem item={blockContent} />);
 
-    TestWithMarks(style, "blockContent-h1");
-    TestWithListItem(style, "blockContent-h1", "bullet");
-    TestWithListItem(style, "blockContent-h1", "number");
-  });
+//       const element = screen.getByTestId(testId);
+//       const code = within(element).getByTestId("blockContent-code");
 
-  describe("style = h2", () => {
-    const style = "h2";
-    it("Renders in a <h2> tag", () => {
-      const blockContent: PortableTextItemType = {
-        _type: "block",
-        _key: "123",
-        markDefs: [],
-        style: style,
-        children: [
-          {
-            _key: "123",
-            _type: "span",
-            text: "Hello",
-            marks: [],
-          },
-        ],
-      };
-      render(<PortableTextItem item={blockContent} />);
+//       expect(code).toBeInTheDocument();
+//     });
+//   });
+//   describe("marks includes a non-standard string", () => {
+//     describe("mark references a markDef of _type='link'", () => {
+//       it("Wraps contents of element in <a>", () => {
+//         const blockContent: PortableTextItemType = generatePortableTextItem(
+//           style,
+//           ["123"],
+//           [{ _type: "link", href: "https://example.com", _key: "123" }],
+//           listItem
+//         );
+//         render(<PortableTextItem item={blockContent} />);
 
-      const element = screen.getByTestId("blockContent-h2");
+//         const element = screen.getByTestId(testId);
+//         const a = within(element).getByTestId("blockContent-a");
 
-      expect(element.nodeName).toBe("H2");
-    });
+//         expect(a.nodeName).toBe("A");
+//       });
+//     });
+//   });
+//   describe("marks include 'strong', 'em', 'underline', 'strikethrough' and 'code'", () => {
+//     it("Wraps contents of element in <strong>, <em>, <underline>, <s> and <code>", () => {
+//       const blockContent: PortableTextItemType = generatePortableTextItem(
+//         style,
+//         ["strong", "em", "underline", "strike-through", "code"],
+//         [],
+//         listItem
+//       );
+//       render(<PortableTextItem item={blockContent} />);
 
-    TestWithMarks(style, "blockContent-h2");
-    TestWithListItem(style, "blockContent-h2", "bullet");
-    TestWithListItem(style, "blockContent-h2", "number");
-  });
+//       const element = screen.getByTestId(testId);
+//       const strong = within(element).getByTestId("blockContent-strong");
+//       const em = within(element).getByTestId("blockContent-em");
+//       const u = within(element).getByTestId("blockContent-u");
+//       const s = within(element).getByTestId("blockContent-s");
+//       const code = within(element).getByTestId("blockContent-code");
 
-  describe("style = h3", () => {
-    const style = "h3";
-    it("Renders in a <h3> tag", () => {
-      const blockContent: PortableTextItemType = {
-        _type: "block",
-        _key: "123",
-        markDefs: [],
-        style: style,
-        children: [
-          {
-            _key: "123",
-            _type: "span",
-            text: "Hello",
-            marks: [],
-          },
-        ],
-      };
-      render(<PortableTextItem item={blockContent} />);
+//       expect(strong.nodeName).toBe("STRONG");
+//       expect(em.nodeName).toBe("EM");
+//       expect(u.nodeName).toBe("U");
+//       expect(s.nodeName).toBe("S");
+//       expect(code).toBeInTheDocument();
+//     });
+//   });
+// };
 
-      const element = screen.getByTestId("blockContent-h3");
+// describe("_type = image", () => {
+//   const withImage: PortableTextItemType = {
+//     _key: "3657e4482fec",
+//     _type: "image",
+//     alt: "my-cool-alt-text",
+//     asset: {
+//       _ref: "image-e5270bee947b5a03a882f377730e52bcf4357ac0-1280x720-png",
+//       _type: "reference",
+//     },
+//   };
 
-      expect(element.nodeName).toBe("H3");
-    });
+//   it("Renders the image", () => {
+//     render(<PortableTextItem item={withImage} />);
 
-    TestWithMarks(style, "blockContent-h3");
-    TestWithListItem(style, "blockContent-h3", "bullet");
-    TestWithListItem(style, "blockContent-h3", "number");
-  });
+//     expect(NextImage).toHaveBeenCalledWith(
+//       expect.objectContaining({
+//         src: withImage.asset._ref,
+//         alt: withImage.alt,
+//       }),
+//       {}
+//     );
+//   });
+// });
 
-  describe("style = h4", () => {
-    const style = "h4";
-    it("Renders in a <h4> tag", () => {
-      const blockContent: PortableTextItemType = {
-        _type: "block",
-        _key: "123",
-        style: style,
-        markDefs: [],
-        children: [
-          {
-            _key: "123",
-            _type: "span",
-            text: "Hello",
-            marks: [],
-          },
-        ],
-      };
-      render(<PortableTextItem item={blockContent} />);
+// describe("_type = block", () => {
+//   describe("text is empty", () => {
+//     const withEmptyText: PortableTextItemType = {
+//       _type: "block",
+//       _key: "123",
+//       markDefs: [],
+//       style: "normal",
+//       children: [
+//         {
+//           _key: "123",
+//           _type: "span",
+//           text: "",
+//           marks: [],
+//         },
+//       ],
+//     };
 
-      const element = screen.getByTestId("blockContent-h4");
+//     it("Renders a <br> tag", () => {
+//       render(<PortableTextItem item={withEmptyText} />);
 
-      expect(element.nodeName).toBe("H4");
-    });
+//       const element = screen.getByTestId("blockContent-br");
 
-    TestWithMarks(style, "blockContent-h4");
-    TestWithListItem(style, "blockContent-h4", "bullet");
-    TestWithListItem(style, "blockContent-h4", "number");
-  });
+//       expect(element.nodeName).toBe("BR");
+//     });
+//   });
+//   describe("style = normal", () => {
+//     const style = "normal"; // <p>
+//     it("Renders in a <p> tag", () => {
+//       const blockContent: PortableTextItemType = {
+//         _type: "block",
+//         _key: "123",
+//         markDefs: [],
+//         style: style,
+//         children: [
+//           {
+//             _key: "123",
+//             _type: "span",
+//             text: "Hello",
+//             marks: [],
+//           },
+//         ],
+//       };
+//       render(<PortableTextItem item={blockContent} />);
 
-  describe("style = h5", () => {
-    const style = "h5";
-    it("Renders in a <h5> tag", () => {
-      const blockContent: PortableTextItemType = {
-        _type: "block",
-        _key: "123",
-        style: style,
-        markDefs: [],
-        children: [
-          {
-            _key: "123",
-            _type: "span",
-            text: "Hello",
-            marks: [],
-          },
-        ],
-      };
-      render(<PortableTextItem item={blockContent} />);
+//       const element = screen.getByTestId("blockContent-p");
 
-      const element = screen.getByTestId("blockContent-h5");
+//       expect(element.nodeName).toBe("P");
+//     });
 
-      expect(element.nodeName).toBe("H5");
-    });
+//     TestWithMarks(style, "blockContent-p");
+//     TestWithListItem(style, "blockContent-p", "bullet");
+//     TestWithListItem(style, "blockContent-p", "number");
+//   });
 
-    TestWithMarks(style, "blockContent-h5");
-    TestWithListItem(style, "blockContent-h5", "bullet");
-    TestWithListItem(style, "blockContent-h5", "number");
-  });
+//   describe("style = blockquote", () => {
+//     const style = "blockquote"; // <p>
+//     it("Renders in a <p> tag with blockquote styling", () => {
+//       const blockContent: PortableTextItemType = {
+//         _type: "block",
+//         _key: "123",
+//         markDefs: [],
+//         style: style,
+//         children: [
+//           {
+//             _key: "123",
+//             _type: "span",
+//             text: "Hello",
+//             marks: [],
+//           },
+//         ],
+//       };
+//       render(<PortableTextItem item={blockContent} />);
 
-  describe("style = h6", () => {
-    const style = "h6";
-    it("Renders in a <h6> tag", () => {
-      const blockContent: PortableTextItemType = {
-        _type: "block",
-        _key: "123",
-        style: style,
-        markDefs: [],
-        children: [
-          {
-            _key: "123",
-            _type: "span",
-            text: "Hello",
-            marks: [],
-          },
-        ],
-      };
-      render(<PortableTextItem item={blockContent} />);
+//       const element = screen.getByTestId("blockContent-blockquote");
 
-      const element = screen.getByTestId("blockContent-h6");
+//       expect(element.nodeName).toBe("DIV");
+//       expect(element.classList.contains("border-l-4")).toBe(true);
+//       expect(element.classList.contains("bg-slate-400")).toBe(true);
+//     });
 
-      expect(element.nodeName).toBe("H6");
-    });
+//     TestWithMarks(style, "blockContent-blockquote");
+//     TestWithListItem(style, "blockContent-blockquote", "bullet");
+//     TestWithListItem(style, "blockContent-blockquote", "number");
+//   });
 
-    TestWithMarks(style, "blockContent-h6");
-    TestWithListItem(style, "blockContent-h6", "bullet");
-    TestWithListItem(style, "blockContent-h6", "number");
-  });
-});
+//   describe("style = h1", () => {
+//     const style = "h1";
+//     it("Renders in a <h1> tag", () => {
+//       const blockContent: PortableTextItemType = {
+//         _type: "block",
+//         _key: "123",
+//         markDefs: [],
+//         style: style,
+//         children: [
+//           {
+//             _key: "123",
+//             _type: "span",
+//             text: "Hello",
+//             marks: [],
+//           },
+//         ],
+//       };
+//       render(<PortableTextItem item={blockContent} />);
+
+//       const element = screen.getByTestId("blockContent-h1");
+
+//       expect(element.nodeName).toBe("H1");
+//     });
+
+//     TestWithMarks(style, "blockContent-h1");
+//     TestWithListItem(style, "blockContent-h1", "bullet");
+//     TestWithListItem(style, "blockContent-h1", "number");
+//   });
+
+//   describe("style = h2", () => {
+//     const style = "h2";
+//     it("Renders in a <h2> tag", () => {
+//       const blockContent: PortableTextItemType = {
+//         _type: "block",
+//         _key: "123",
+//         markDefs: [],
+//         style: style,
+//         children: [
+//           {
+//             _key: "123",
+//             _type: "span",
+//             text: "Hello",
+//             marks: [],
+//           },
+//         ],
+//       };
+//       render(<PortableTextItem item={blockContent} />);
+
+//       const element = screen.getByTestId("blockContent-h2");
+
+//       expect(element.nodeName).toBe("H2");
+//     });
+
+//     TestWithMarks(style, "blockContent-h2");
+//     TestWithListItem(style, "blockContent-h2", "bullet");
+//     TestWithListItem(style, "blockContent-h2", "number");
+//   });
+
+//   describe("style = h3", () => {
+//     const style = "h3";
+//     it("Renders in a <h3> tag", () => {
+//       const blockContent: PortableTextItemType = {
+//         _type: "block",
+//         _key: "123",
+//         markDefs: [],
+//         style: style,
+//         children: [
+//           {
+//             _key: "123",
+//             _type: "span",
+//             text: "Hello",
+//             marks: [],
+//           },
+//         ],
+//       };
+//       render(<PortableTextItem item={blockContent} />);
+
+//       const element = screen.getByTestId("blockContent-h3");
+
+//       expect(element.nodeName).toBe("H3");
+//     });
+
+//     TestWithMarks(style, "blockContent-h3");
+//     TestWithListItem(style, "blockContent-h3", "bullet");
+//     TestWithListItem(style, "blockContent-h3", "number");
+//   });
+
+//   describe("style = h4", () => {
+//     const style = "h4";
+//     it("Renders in a <h4> tag", () => {
+//       const blockContent: PortableTextItemType = {
+//         _type: "block",
+//         _key: "123",
+//         style: style,
+//         markDefs: [],
+//         children: [
+//           {
+//             _key: "123",
+//             _type: "span",
+//             text: "Hello",
+//             marks: [],
+//           },
+//         ],
+//       };
+//       render(<PortableTextItem item={blockContent} />);
+
+//       const element = screen.getByTestId("blockContent-h4");
+
+//       expect(element.nodeName).toBe("H4");
+//     });
+
+//     TestWithMarks(style, "blockContent-h4");
+//     TestWithListItem(style, "blockContent-h4", "bullet");
+//     TestWithListItem(style, "blockContent-h4", "number");
+//   });
+
+//   describe("style = h5", () => {
+//     const style = "h5";
+//     it("Renders in a <h5> tag", () => {
+//       const blockContent: PortableTextItemType = {
+//         _type: "block",
+//         _key: "123",
+//         style: style,
+//         markDefs: [],
+//         children: [
+//           {
+//             _key: "123",
+//             _type: "span",
+//             text: "Hello",
+//             marks: [],
+//           },
+//         ],
+//       };
+//       render(<PortableTextItem item={blockContent} />);
+
+//       const element = screen.getByTestId("blockContent-h5");
+
+//       expect(element.nodeName).toBe("H5");
+//     });
+
+//     TestWithMarks(style, "blockContent-h5");
+//     TestWithListItem(style, "blockContent-h5", "bullet");
+//     TestWithListItem(style, "blockContent-h5", "number");
+//   });
+
+//   describe("style = h6", () => {
+//     const style = "h6";
+//     it("Renders in a <h6> tag", () => {
+//       const blockContent: PortableTextItemType = {
+//         _type: "block",
+//         _key: "123",
+//         style: style,
+//         markDefs: [],
+//         children: [
+//           {
+//             _key: "123",
+//             _type: "span",
+//             text: "Hello",
+//             marks: [],
+//           },
+//         ],
+//       };
+//       render(<PortableTextItem item={blockContent} />);
+
+//       const element = screen.getByTestId("blockContent-h6");
+
+//       expect(element.nodeName).toBe("H6");
+//     });
+
+//     TestWithMarks(style, "blockContent-h6");
+//     TestWithListItem(style, "blockContent-h6", "bullet");
+//     TestWithListItem(style, "blockContent-h6", "number");
+//   });
+// });

--- a/__tests__/PortableTextItem.test.tsx
+++ b/__tests__/PortableTextItem.test.tsx
@@ -20,15 +20,104 @@ jest.mock("../sanity/client", () => ({
   urlFor: (url: string) => ({ url: () => url }),
 }));
 
+const getTagFromStyle = (style: Style): string => {
+  let tag: string = style;
+  if (style === "normal") {
+    tag = "p";
+  }
+  if (style === "blockquote") {
+    tag = "div";
+  }
+  return tag;
+};
+
+const marksToTest = [
+  { name: "strong", tag: "strong" },
+  { name: "em", tag: "em" },
+  { name: "underline", tag: "u" },
+  { name: "strike-through", tag: "s" },
+  { name: "code", tag: "code" },
+];
+const testWithMarks = (
+  listItem: "bullet" | "number" | undefined,
+  style: Style
+) => {
+  marksToTest.forEach(({ name, tag }) => {
+    describe(`and marks includes '${name}'`, () => {
+      it(`wraps contents in a <${tag}> tag`, () => {
+        const portableTextItem: PortableTextItemType = generatePortableTextItem(
+          style,
+          [name],
+          [],
+          listItem
+        );
+        const { container } = render(
+          <PortableTextItem item={portableTextItem} />
+        );
+
+        const parentTag = getTagFromStyle(style);
+        const parentElement = container.querySelector(parentTag);
+        const markElement = parentElement?.querySelector(tag);
+
+        expect(markElement).toBeTruthy();
+      });
+    });
+  });
+
+  describe("and marks includes 'em', 'strong', 'underline' and 'strike-through'", () => {
+    it("wraps contents in <em>, <strong>, <u> and <s> tags", () => {
+      const portableTextItem: PortableTextItemType = generatePortableTextItem(
+        style,
+        ["em", "strong", "underline", "strike-through"],
+        [],
+        listItem
+      );
+      const { container } = render(
+        <PortableTextItem item={portableTextItem} />
+      );
+
+      const parentTag = getTagFromStyle(style);
+      const parentElement = container.querySelector(parentTag);
+      const emTag = parentElement?.querySelector("em");
+      const strongTag = parentElement?.querySelector("strong");
+      const underlineTag = parentElement?.querySelector("u");
+      const strikethroughTag = parentElement?.querySelector("s");
+
+      expect(emTag).toBeTruthy();
+      expect(strongTag).toBeTruthy();
+      expect(underlineTag).toBeTruthy();
+      expect(strikethroughTag).toBeTruthy();
+    });
+  });
+
+  describe("and marks includes a non-standard string", () => {
+    describe("and the mark references a markDef of _type='link'", () => {
+      it("Wraps contents of element in an <a> tag", () => {
+        const href = "https://example.com/";
+        const portableTextItem: PortableTextItemType = generatePortableTextItem(
+          style,
+          ["123"],
+          [{ _type: "link", href, _key: "123" }],
+          listItem
+        );
+
+        const { container } = render(
+          <PortableTextItem item={portableTextItem} />
+        );
+        const parentTag = getTagFromStyle(style);
+        const parentElement = container.querySelector(parentTag);
+        const anchorTag = parentElement?.querySelector("a");
+
+        expect(anchorTag).toBeTruthy();
+        expect(anchorTag?.href).toBe(href);
+      });
+    });
+  });
+};
+
 const testWithStyles = (listItem: "bullet" | "number" | undefined) => {
   STYLES.forEach((style) => {
-    let tag: string = style;
-    if (style === "normal") {
-      tag = "p";
-    }
-    if (style === "blockquote") {
-      tag = "div";
-    }
+    const tag = getTagFromStyle(style);
 
     describe(`and style = ${style}`, () => {
       it(`Renders in a <${tag}> tag`, () => {
@@ -53,466 +142,69 @@ const testWithStyles = (listItem: "bullet" | "number" | undefined) => {
 
         expect(styleElement).toBeTruthy();
       });
+
+      testWithMarks(listItem, style);
     });
   });
 };
 
-describe("With no list styles", () => {
-  testWithStyles(undefined);
+describe("_type = image", () => {
+  const withImage: PortableTextItemType = {
+    _key: "3657e4482fec",
+    _type: "image",
+    alt: "my-cool-alt-text",
+    asset: {
+      _ref: "image-e5270bee947b5a03a882f377730e52bcf4357ac0-1280x720-png",
+      _type: "reference",
+    },
+  };
+
+  it("Renders the image", () => {
+    render(<PortableTextItem item={withImage} />);
+
+    expect(NextImage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        src: withImage.asset._ref,
+        alt: withImage.alt,
+      }),
+      {}
+    );
+  });
 });
-describe("With bullet list styles", () => {
-  testWithStyles("bullet");
+
+describe("_type = block", () => {
+  describe("text is empty", () => {
+    const withEmptyText: PortableTextItemType = {
+      _type: "block",
+      _key: "123",
+      markDefs: [],
+      style: "normal",
+      children: [
+        {
+          _key: "123",
+          _type: "span",
+          text: "",
+          marks: [],
+        },
+      ],
+    };
+
+    it("Renders a <br> tag", () => {
+      render(<PortableTextItem item={withEmptyText} />);
+
+      const element = screen.getByTestId("blockContent-br");
+
+      expect(element.nodeName).toBe("BR");
+    });
+  });
+
+  describe("With no list styles", () => {
+    testWithStyles(undefined);
+  });
+  describe("With bullet list styles", () => {
+    testWithStyles("bullet");
+  });
+  describe("With numbered list styles", () => {
+    testWithStyles("number");
+  });
 });
-describe("With numbered list styles", () => {
-  testWithStyles("number");
-});
-
-// const TestWithListItem = (
-//   style: Style,
-//   testId: string,
-//   listItem: "bullet" | "number"
-// ) => {
-//   const props: PortableTextItemType = {
-//     _type: "block",
-//     _key: "123",
-//     style: style,
-//     markDefs: [],
-//     children: [
-//       {
-//         _key: "123",
-//         _type: "span",
-//         text: "Hello",
-//         marks: [],
-//       },
-//     ],
-//     listItem,
-//     level: 1,
-//   };
-
-//   describe("listItem = 'bullet' | 'number'", () => {
-//     it("Renders text content in a <li> tag within element", () => {
-//       render(<PortableTextItem item={props} />);
-
-//       const li = screen.getByTestId("blockContent-li");
-//       const element = within(li).getByTestId(testId);
-
-//       expect(li.nodeName).toBe("LI");
-//       expect(element).toBeInTheDocument();
-//     });
-
-//     TestWithMarks(style, "blockContent-li", "bullet");
-//   });
-// };
-
-// const TestWithMarks = (
-//   style: Style,
-//   testId: string,
-//   listItem?: "bullet" | "number"
-// ) => {
-//   describe("marks includes 'em'", () => {
-//     it("Wraps contents of element in <em>", () => {
-//       const blockContent: PortableTextItemType = generatePortableTextItem(
-//         style,
-//         ["em"],
-//         [],
-//         listItem
-//       );
-//       render(<PortableTextItem item={blockContent} />);
-
-//       const element = screen.getByTestId(testId);
-//       const em = within(element).getByTestId("blockContent-em");
-
-//       expect(em.nodeName).toBe("EM");
-//     });
-//   });
-//   describe("marks includes 'strong'", () => {
-//     it("Wraps contents of element in <strong>", () => {
-//       const blockContent: PortableTextItemType = generatePortableTextItem(
-//         style,
-//         ["strong"],
-//         [],
-//         listItem
-//       );
-//       render(<PortableTextItem item={blockContent} />);
-
-//       const element = screen.getByTestId(testId);
-//       const strong = within(element).getByTestId("blockContent-strong");
-
-//       expect(strong.nodeName).toBe("STRONG");
-//     });
-//   });
-//   describe("marks includes 'underline'", () => {
-//     it("Wraps contents of element in <u>", () => {
-//       const blockContent: PortableTextItemType = generatePortableTextItem(
-//         style,
-//         ["underline"],
-//         [],
-//         listItem
-//       );
-//       render(<PortableTextItem item={blockContent} />);
-
-//       const element = screen.getByTestId(testId);
-//       const underline = within(element).getByTestId("blockContent-u");
-
-//       expect(underline.nodeName).toBe("U");
-//     });
-//   });
-//   describe("marks includes 'strikethrough'", () => {
-//     it("Wraps contents of element in <s>", () => {
-//       const blockContent: PortableTextItemType = generatePortableTextItem(
-//         style,
-//         ["strike-through"],
-//         [],
-//         listItem
-//       );
-//       render(<PortableTextItem item={blockContent} />);
-
-//       const element = screen.getByTestId(testId);
-//       const strikethrough = within(element).getByTestId("blockContent-s");
-
-//       expect(strikethrough.nodeName).toBe("S");
-//     });
-//   });
-//   describe("marks includes 'code'", () => {
-//     it("Wraps contents of element in <code>", () => {
-//       const blockContent: PortableTextItemType = generatePortableTextItem(
-//         style,
-//         ["code"],
-//         [],
-//         listItem
-//       );
-//       render(<PortableTextItem item={blockContent} />);
-
-//       const element = screen.getByTestId(testId);
-//       const code = within(element).getByTestId("blockContent-code");
-
-//       expect(code).toBeInTheDocument();
-//     });
-//   });
-//   describe("marks includes a non-standard string", () => {
-//     describe("mark references a markDef of _type='link'", () => {
-//       it("Wraps contents of element in <a>", () => {
-//         const blockContent: PortableTextItemType = generatePortableTextItem(
-//           style,
-//           ["123"],
-//           [{ _type: "link", href: "https://example.com", _key: "123" }],
-//           listItem
-//         );
-//         render(<PortableTextItem item={blockContent} />);
-
-//         const element = screen.getByTestId(testId);
-//         const a = within(element).getByTestId("blockContent-a");
-
-//         expect(a.nodeName).toBe("A");
-//       });
-//     });
-//   });
-//   describe("marks include 'strong', 'em', 'underline', 'strikethrough' and 'code'", () => {
-//     it("Wraps contents of element in <strong>, <em>, <underline>, <s> and <code>", () => {
-//       const blockContent: PortableTextItemType = generatePortableTextItem(
-//         style,
-//         ["strong", "em", "underline", "strike-through", "code"],
-//         [],
-//         listItem
-//       );
-//       render(<PortableTextItem item={blockContent} />);
-
-//       const element = screen.getByTestId(testId);
-//       const strong = within(element).getByTestId("blockContent-strong");
-//       const em = within(element).getByTestId("blockContent-em");
-//       const u = within(element).getByTestId("blockContent-u");
-//       const s = within(element).getByTestId("blockContent-s");
-//       const code = within(element).getByTestId("blockContent-code");
-
-//       expect(strong.nodeName).toBe("STRONG");
-//       expect(em.nodeName).toBe("EM");
-//       expect(u.nodeName).toBe("U");
-//       expect(s.nodeName).toBe("S");
-//       expect(code).toBeInTheDocument();
-//     });
-//   });
-// };
-
-// describe("_type = image", () => {
-//   const withImage: PortableTextItemType = {
-//     _key: "3657e4482fec",
-//     _type: "image",
-//     alt: "my-cool-alt-text",
-//     asset: {
-//       _ref: "image-e5270bee947b5a03a882f377730e52bcf4357ac0-1280x720-png",
-//       _type: "reference",
-//     },
-//   };
-
-//   it("Renders the image", () => {
-//     render(<PortableTextItem item={withImage} />);
-
-//     expect(NextImage).toHaveBeenCalledWith(
-//       expect.objectContaining({
-//         src: withImage.asset._ref,
-//         alt: withImage.alt,
-//       }),
-//       {}
-//     );
-//   });
-// });
-
-// describe("_type = block", () => {
-//   describe("text is empty", () => {
-//     const withEmptyText: PortableTextItemType = {
-//       _type: "block",
-//       _key: "123",
-//       markDefs: [],
-//       style: "normal",
-//       children: [
-//         {
-//           _key: "123",
-//           _type: "span",
-//           text: "",
-//           marks: [],
-//         },
-//       ],
-//     };
-
-//     it("Renders a <br> tag", () => {
-//       render(<PortableTextItem item={withEmptyText} />);
-
-//       const element = screen.getByTestId("blockContent-br");
-
-//       expect(element.nodeName).toBe("BR");
-//     });
-//   });
-//   describe("style = normal", () => {
-//     const style = "normal"; // <p>
-//     it("Renders in a <p> tag", () => {
-//       const blockContent: PortableTextItemType = {
-//         _type: "block",
-//         _key: "123",
-//         markDefs: [],
-//         style: style,
-//         children: [
-//           {
-//             _key: "123",
-//             _type: "span",
-//             text: "Hello",
-//             marks: [],
-//           },
-//         ],
-//       };
-//       render(<PortableTextItem item={blockContent} />);
-
-//       const element = screen.getByTestId("blockContent-p");
-
-//       expect(element.nodeName).toBe("P");
-//     });
-
-//     TestWithMarks(style, "blockContent-p");
-//     TestWithListItem(style, "blockContent-p", "bullet");
-//     TestWithListItem(style, "blockContent-p", "number");
-//   });
-
-//   describe("style = blockquote", () => {
-//     const style = "blockquote"; // <p>
-//     it("Renders in a <p> tag with blockquote styling", () => {
-//       const blockContent: PortableTextItemType = {
-//         _type: "block",
-//         _key: "123",
-//         markDefs: [],
-//         style: style,
-//         children: [
-//           {
-//             _key: "123",
-//             _type: "span",
-//             text: "Hello",
-//             marks: [],
-//           },
-//         ],
-//       };
-//       render(<PortableTextItem item={blockContent} />);
-
-//       const element = screen.getByTestId("blockContent-blockquote");
-
-//       expect(element.nodeName).toBe("DIV");
-//       expect(element.classList.contains("border-l-4")).toBe(true);
-//       expect(element.classList.contains("bg-slate-400")).toBe(true);
-//     });
-
-//     TestWithMarks(style, "blockContent-blockquote");
-//     TestWithListItem(style, "blockContent-blockquote", "bullet");
-//     TestWithListItem(style, "blockContent-blockquote", "number");
-//   });
-
-//   describe("style = h1", () => {
-//     const style = "h1";
-//     it("Renders in a <h1> tag", () => {
-//       const blockContent: PortableTextItemType = {
-//         _type: "block",
-//         _key: "123",
-//         markDefs: [],
-//         style: style,
-//         children: [
-//           {
-//             _key: "123",
-//             _type: "span",
-//             text: "Hello",
-//             marks: [],
-//           },
-//         ],
-//       };
-//       render(<PortableTextItem item={blockContent} />);
-
-//       const element = screen.getByTestId("blockContent-h1");
-
-//       expect(element.nodeName).toBe("H1");
-//     });
-
-//     TestWithMarks(style, "blockContent-h1");
-//     TestWithListItem(style, "blockContent-h1", "bullet");
-//     TestWithListItem(style, "blockContent-h1", "number");
-//   });
-
-//   describe("style = h2", () => {
-//     const style = "h2";
-//     it("Renders in a <h2> tag", () => {
-//       const blockContent: PortableTextItemType = {
-//         _type: "block",
-//         _key: "123",
-//         markDefs: [],
-//         style: style,
-//         children: [
-//           {
-//             _key: "123",
-//             _type: "span",
-//             text: "Hello",
-//             marks: [],
-//           },
-//         ],
-//       };
-//       render(<PortableTextItem item={blockContent} />);
-
-//       const element = screen.getByTestId("blockContent-h2");
-
-//       expect(element.nodeName).toBe("H2");
-//     });
-
-//     TestWithMarks(style, "blockContent-h2");
-//     TestWithListItem(style, "blockContent-h2", "bullet");
-//     TestWithListItem(style, "blockContent-h2", "number");
-//   });
-
-//   describe("style = h3", () => {
-//     const style = "h3";
-//     it("Renders in a <h3> tag", () => {
-//       const blockContent: PortableTextItemType = {
-//         _type: "block",
-//         _key: "123",
-//         markDefs: [],
-//         style: style,
-//         children: [
-//           {
-//             _key: "123",
-//             _type: "span",
-//             text: "Hello",
-//             marks: [],
-//           },
-//         ],
-//       };
-//       render(<PortableTextItem item={blockContent} />);
-
-//       const element = screen.getByTestId("blockContent-h3");
-
-//       expect(element.nodeName).toBe("H3");
-//     });
-
-//     TestWithMarks(style, "blockContent-h3");
-//     TestWithListItem(style, "blockContent-h3", "bullet");
-//     TestWithListItem(style, "blockContent-h3", "number");
-//   });
-
-//   describe("style = h4", () => {
-//     const style = "h4";
-//     it("Renders in a <h4> tag", () => {
-//       const blockContent: PortableTextItemType = {
-//         _type: "block",
-//         _key: "123",
-//         style: style,
-//         markDefs: [],
-//         children: [
-//           {
-//             _key: "123",
-//             _type: "span",
-//             text: "Hello",
-//             marks: [],
-//           },
-//         ],
-//       };
-//       render(<PortableTextItem item={blockContent} />);
-
-//       const element = screen.getByTestId("blockContent-h4");
-
-//       expect(element.nodeName).toBe("H4");
-//     });
-
-//     TestWithMarks(style, "blockContent-h4");
-//     TestWithListItem(style, "blockContent-h4", "bullet");
-//     TestWithListItem(style, "blockContent-h4", "number");
-//   });
-
-//   describe("style = h5", () => {
-//     const style = "h5";
-//     it("Renders in a <h5> tag", () => {
-//       const blockContent: PortableTextItemType = {
-//         _type: "block",
-//         _key: "123",
-//         style: style,
-//         markDefs: [],
-//         children: [
-//           {
-//             _key: "123",
-//             _type: "span",
-//             text: "Hello",
-//             marks: [],
-//           },
-//         ],
-//       };
-//       render(<PortableTextItem item={blockContent} />);
-
-//       const element = screen.getByTestId("blockContent-h5");
-
-//       expect(element.nodeName).toBe("H5");
-//     });
-
-//     TestWithMarks(style, "blockContent-h5");
-//     TestWithListItem(style, "blockContent-h5", "bullet");
-//     TestWithListItem(style, "blockContent-h5", "number");
-//   });
-
-//   describe("style = h6", () => {
-//     const style = "h6";
-//     it("Renders in a <h6> tag", () => {
-//       const blockContent: PortableTextItemType = {
-//         _type: "block",
-//         _key: "123",
-//         style: style,
-//         markDefs: [],
-//         children: [
-//           {
-//             _key: "123",
-//             _type: "span",
-//             text: "Hello",
-//             marks: [],
-//           },
-//         ],
-//       };
-//       render(<PortableTextItem item={blockContent} />);
-
-//       const element = screen.getByTestId("blockContent-h6");
-
-//       expect(element.nodeName).toBe("H6");
-//     });
-
-//     TestWithMarks(style, "blockContent-h6");
-//     TestWithListItem(style, "blockContent-h6", "bullet");
-//     TestWithListItem(style, "blockContent-h6", "number");
-//   });
-// });

--- a/__tests__/PortableTextItem.test.tsx
+++ b/__tests__/PortableTextItem.test.tsx
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom";
 import { screen, render, within } from "@testing-library/react";
 import NextImage from "next/image";
 
+import { generatePortableTextItem } from "@/stories/dummyBlockContent";
 import { PortableTextItem } from "@components/PortableTextItem";
 import {
   PortableTextItem as PortableTextItemType,
@@ -61,30 +62,14 @@ const TestWithMarks = (
   testId: string,
   listItem?: "bullet" | "number"
 ) => {
-  const generatePropsWithMarks = (
-    marks: Mark[],
-    markDefs: MarkDef[] = []
-  ): PortableTextItemType => {
-    const listItemProps = listItem ? { listItem: listItem, level: 1 } : {};
-    return {
-      _type: "block",
-      _key: "123",
-      markDefs,
-      style: style,
-      children: [
-        {
-          _key: "123",
-          _type: "span",
-          marks: marks,
-          text: "Hello",
-        },
-      ],
-      ...listItemProps,
-    };
-  };
   describe("marks includes 'em'", () => {
     it("Wraps contents of element in <em>", () => {
-      const blockContent: PortableTextItemType = generatePropsWithMarks(["em"]);
+      const blockContent: PortableTextItemType = generatePortableTextItem(
+        style,
+        ["em"],
+        [],
+        listItem
+      );
       render(<PortableTextItem item={blockContent} />);
 
       const element = screen.getByTestId(testId);
@@ -95,9 +80,12 @@ const TestWithMarks = (
   });
   describe("marks includes 'strong'", () => {
     it("Wraps contents of element in <strong>", () => {
-      const blockContent: PortableTextItemType = generatePropsWithMarks([
-        "strong",
-      ]);
+      const blockContent: PortableTextItemType = generatePortableTextItem(
+        style,
+        ["strong"],
+        [],
+        listItem
+      );
       render(<PortableTextItem item={blockContent} />);
 
       const element = screen.getByTestId(testId);
@@ -108,9 +96,12 @@ const TestWithMarks = (
   });
   describe("marks includes 'underline'", () => {
     it("Wraps contents of element in <u>", () => {
-      const blockContent: PortableTextItemType = generatePropsWithMarks([
-        "underline",
-      ]);
+      const blockContent: PortableTextItemType = generatePortableTextItem(
+        style,
+        ["underline"],
+        [],
+        listItem
+      );
       render(<PortableTextItem item={blockContent} />);
 
       const element = screen.getByTestId(testId);
@@ -121,9 +112,12 @@ const TestWithMarks = (
   });
   describe("marks includes 'strikethrough'", () => {
     it("Wraps contents of element in <s>", () => {
-      const blockContent: PortableTextItemType = generatePropsWithMarks([
-        "strike-through",
-      ]);
+      const blockContent: PortableTextItemType = generatePortableTextItem(
+        style,
+        ["strike-through"],
+        [],
+        listItem
+      );
       render(<PortableTextItem item={blockContent} />);
 
       const element = screen.getByTestId(testId);
@@ -134,9 +128,12 @@ const TestWithMarks = (
   });
   describe("marks includes 'code'", () => {
     it("Wraps contents of element in <code>", () => {
-      const blockContent: PortableTextItemType = generatePropsWithMarks([
-        "code",
-      ]);
+      const blockContent: PortableTextItemType = generatePortableTextItem(
+        style,
+        ["code"],
+        [],
+        listItem
+      );
       render(<PortableTextItem item={blockContent} />);
 
       const element = screen.getByTestId(testId);
@@ -148,9 +145,11 @@ const TestWithMarks = (
   describe("marks includes a non-standard string", () => {
     describe("mark references a markDef of _type='link'", () => {
       it("Wraps contents of element in <a>", () => {
-        const blockContent: PortableTextItemType = generatePropsWithMarks(
+        const blockContent: PortableTextItemType = generatePortableTextItem(
+          style,
           ["123"],
-          [{ _type: "link", href: "https://example.com", _key: "123" }]
+          [{ _type: "link", href: "https://example.com", _key: "123" }],
+          listItem
         );
         render(<PortableTextItem item={blockContent} />);
 
@@ -163,13 +162,12 @@ const TestWithMarks = (
   });
   describe("marks include 'strong', 'em', 'underline', 'strikethrough' and 'code'", () => {
     it("Wraps contents of element in <strong>, <em>, <underline>, <s> and <code>", () => {
-      const blockContent: PortableTextItemType = generatePropsWithMarks([
-        "strong",
-        "em",
-        "underline",
-        "strike-through",
-        "code",
-      ]);
+      const blockContent: PortableTextItemType = generatePortableTextItem(
+        style,
+        ["strong", "em", "underline", "strike-through", "code"],
+        [],
+        listItem
+      );
       render(<PortableTextItem item={blockContent} />);
 
       const element = screen.getByTestId(testId);

--- a/app/_components/BlockItem.tsx
+++ b/app/_components/BlockItem.tsx
@@ -6,9 +6,13 @@ type WithListItemProps = {
 };
 const WithListItem = ({ listItem, children }: WithListItemProps) => {
   if (listItem === "bullet" || listItem === "number") {
-    return <li data-testid="blockContent-li">{children}</li>;
+    return <li>{children}</li>;
   }
-  return <div className="my-8">{children}</div>;
+  return (
+    <div className="my-8" data-testid="blockContentDivWrapper">
+      {children}
+    </div>
+  );
 };
 
 type WithStyleProps = {
@@ -62,7 +66,7 @@ const WithStyle = ({ style, children }: WithStyleProps) => {
     return (
       <div
         className="border-l-4 border-slate-900 bg-slate-400 p-8"
-        data-testid="blockContent-blockquote"
+        data-testid="blockContentBlockQuote"
       >
         {children}
       </div>

--- a/app/_components/BlockItem.tsx
+++ b/app/_components/BlockItem.tsx
@@ -20,54 +20,22 @@ type WithStyleProps = {
   children: React.ReactNode;
 };
 const WithStyle = ({ style, children }: WithStyleProps) => {
-  if (style === "normal")
-    return (
-      <p className="text-slate-900" data-testid="blockContent-p">
-        {children}
-      </p>
-    );
+  if (style === "normal") return <p className="text-slate-900">{children}</p>;
   if (style === "h1")
-    return (
-      <h1 className="text-30 text-slate-900" data-testid="blockContent-h1">
-        {children}
-      </h1>
-    );
+    return <h1 className="text-30 text-slate-900">{children}</h1>;
   if (style === "h2")
-    return (
-      <h2 className="text-24 text-slate-900" data-testid="blockContent-h2">
-        {children}
-      </h2>
-    );
+    return <h2 className="text-24 text-slate-900">{children}</h2>;
   if (style === "h3")
-    return (
-      <h3 className="text-20 text-slate-900" data-testid="blockContent-h3">
-        {children}
-      </h3>
-    );
+    return <h3 className="text-20 text-slate-900">{children}</h3>;
   if (style === "h4")
-    return (
-      <h4 className="text-18 text-slate-900" data-testid="blockContent-h4">
-        {children}
-      </h4>
-    );
+    return <h4 className="text-18 text-slate-900">{children}</h4>;
   if (style === "h5")
-    return (
-      <h5 className="text-16 text-slate-900" data-testid="blockContent-h5">
-        {children}
-      </h5>
-    );
+    return <h5 className="text-16 text-slate-900">{children}</h5>;
   if (style === "h6")
-    return (
-      <h6 className="text-14 text-slate-900" data-testid="blockContent-h6">
-        {children}
-      </h6>
-    );
+    return <h6 className="text-14 text-slate-900">{children}</h6>;
   if (style === "blockquote")
     return (
-      <div
-        className="border-l-4 border-slate-900 bg-slate-400 p-8"
-        data-testid="blockContentBlockQuote"
-      >
+      <div className="border-l-4 border-slate-900 bg-slate-400 p-8">
         {children}
       </div>
     );
@@ -85,21 +53,16 @@ const WithMarks = ({ blockChild, markDefs }: WithMarksProps) => {
   let element: React.ReactNode = text;
   marks.forEach((mark) => {
     if (mark === "strong") {
-      element = <strong data-testid="blockContent-strong">{element}</strong>;
+      element = <strong>{element}</strong>;
     } else if (mark === "em") {
-      element = <em data-testid="blockContent-em">{element}</em>;
+      element = <em>{element}</em>;
     } else if (mark === "underline") {
-      element = <u data-testid="blockContent-u">{element}</u>;
+      element = <u>{element}</u>;
     } else if (mark === "strike-through") {
-      element = <s data-testid="blockContent-s">{element}</s>;
+      element = <s>{element}</s>;
     } else if (mark === "code") {
       element = (
-        <code
-          className="bg-slate-900 text-slate-300 px-4"
-          data-testid="blockContent-code"
-        >
-          {element}
-        </code>
+        <code className="bg-slate-900 text-slate-300 px-4">{element}</code>
       );
     } else {
       // In this case, mark may be a reference to a markdef _key field
@@ -107,12 +70,7 @@ const WithMarks = ({ blockChild, markDefs }: WithMarksProps) => {
       markDefs?.forEach((markDef) => {
         if (markDef._key === mark && markDef._type === "link") {
           element = (
-            <a
-              className="underline"
-              target="_blank"
-              href={markDef.href}
-              data-testid="blockContent-a"
-            >
+            <a className="underline" target="_blank" href={markDef.href}>
               {element}
             </a>
           );
@@ -133,8 +91,7 @@ export const BlockItem = ({ item }: BlockItemProps) => {
     <WithListItem listItem={listItem}>
       <WithStyle style={style}>
         {children.map((child, i) => {
-          if (child.text === "")
-            return <br key={i} data-testid="blockContent-br" />;
+          if (child.text === "") return <br key={i} />;
 
           return <WithMarks key={i} blockChild={child} markDefs={markDefs} />;
         })}

--- a/stories/dummyBlockContent.ts
+++ b/stories/dummyBlockContent.ts
@@ -17,7 +17,7 @@ const STYLES = [
   "blockquote",
 ] as const;
 
-const generatePortableTextItem = (
+export const generatePortableTextItem = (
   style: Style,
   marks: Mark[] = [],
   markDefs: MarkDef[] = [],

--- a/stories/dummyBlockContent.ts
+++ b/stories/dummyBlockContent.ts
@@ -6,7 +6,7 @@ import {
   PortableTextWithListItemsGrouped,
 } from "@customTypes/PortableTextTypes";
 
-const STYLES = [
+export const STYLES = [
   "h1",
   "h2",
   "h3",


### PR DESCRIPTION
Refactors the iterative tests in `PortableTextItem.test.tsx` so that they execute in the same order that `PortableTextItem.tsx` wraps its children. That is:
1. Each `listItem` value will be tested, then run the tests for styles
2. The `style` tests will be run from within each `listItem` test, then run the tests for `marks`
3. The `marks` tests will be run from within each `style` test

This means that each `mark` gets tested with each `style`, and each `style` gets tested with each `listItem`.

This leads to a test coverage of 197 different combinations of `listItem`, `style` and `marks`.
It also leads to verbose test output that better indicates the hierarchy  of these three fields:
<img width="721" alt="image" src="https://github.com/user-attachments/assets/767dc9c7-2359-4be9-b44e-6bb1cfb06442">