### PR TITLE
Implement use hook

### DIFF
--- a/app/(routes)/articles/[slug]/page.tsx
+++ b/app/(routes)/articles/[slug]/page.tsx
@@ -1,30 +1,11 @@
-import { cache } from "react";
+import { cache, Suspense } from "react";
 import { client } from "@/sanity/client";
-import { PortableTextItem } from "@customTypes/PortableTextTypes";
 import { Metadata } from "next";
 
-import { Article } from "@components/Article";
+import { Article, ArticleData } from "@components/Article";
 import { BackButton } from "@components/BackButton";
 import { EndOfPageBackButton } from "@components/EndOfPageBackButton";
-
-type Slug = {
-  current: string;
-};
-type Tag = {
-  value: string;
-};
-export type ArticleData = {
-  _createdAt: string;
-  title: string;
-  jpTitle: string;
-  slug: Slug;
-  description: string;
-  jpDescription: string;
-  tags: Tag[];
-  jpTags: Tag[];
-  mainContent: PortableTextItem[];
-  jpMainContent: PortableTextItem[];
-};
+import { LoadingSpinner } from "@components/LoadingSpinner";
 
 const getArticle = cache(async (slug: string) => {
   const article = await client.fetch<ArticleData>(
@@ -58,53 +39,32 @@ type ArticleProps = {
   };
 };
 
-export async function generateMetadata({
-  params,
-}: ArticleProps): Promise<Metadata> {
-  const { slug } = params;
-  const article = await getArticle(slug);
+// TODO: Find a way to re-implement this, without causing a delay in the rendering of the page
+// Currently, this will stop the page from appearing until getArticle has finished
 
-  return {
-    title: article.title,
-    description: article.description,
-  };
-}
+// export async function generateMetadata({
+//   params,
+// }: ArticleProps): Promise<Metadata> {
+//   const { slug } = params;
+//   const article = await getArticle(slug);
 
-export default async function Page({ params }: ArticleProps) {
-  const article = await getArticle(params.slug);
+//   return {
+//     title: article.title,
+//     description: article.description,
+//   };
+// }
 
-  if (!article) {
-    return <div>Article of slug {params.slug} not found</div>;
-  }
-
-  const {
-    _createdAt: createdAt,
-    title,
-    jpTitle,
-    description,
-    jpDescription,
-    tags,
-    jpTags,
-    mainContent,
-    jpMainContent,
-  } = article;
+export default function Page({ params }: ArticleProps) {
+  const articlePromise = getArticle(params.slug);
 
   return (
     <div className="relative">
       <div className="w-full flex justify-center">
         <div className="w-11/12 max-w-1040">
           <BackButton />
-          <Article
-            createdAt={createdAt}
-            title={title}
-            jpTitle={jpTitle}
-            description={description}
-            jpDescription={jpDescription}
-            tags={tags}
-            jpTags={jpTags}
-            mainContent={mainContent}
-            jpMainContent={jpMainContent}
-          />
+          <Suspense fallback={<LoadingSpinner />}>
+            <Article articlePromise={articlePromise} />
+          </Suspense>
           <EndOfPageBackButton />
         </div>
       </div>

--- a/app/(routes)/articles/[slug]/page.tsx
+++ b/app/(routes)/articles/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { cache, Suspense } from "react";
 import { client } from "@/sanity/client";
-import { Metadata } from "next";
+// import { Metadata } from "next";
 
 import { Article, ArticleData } from "@components/Article";
 import { BackButton } from "@components/BackButton";

--- a/app/(routes)/articles/[slug]/page.tsx
+++ b/app/(routes)/articles/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { cache, Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
 import { client } from "@/sanity/client";
 // import { Metadata } from "next";
 
@@ -6,6 +7,7 @@ import { Article, ArticleData } from "@components/Article";
 import { BackButton } from "@components/BackButton";
 import { EndOfPageBackButton } from "@components/EndOfPageBackButton";
 import { LoadingSpinner } from "@components/LoadingSpinner";
+import { ArticleNotFound } from "@components/ArticleNotFound";
 
 const getArticle = cache(async (slug: string) => {
   const article = await client.fetch<ArticleData>(
@@ -62,16 +64,18 @@ export default function Page({ params }: ArticleProps) {
       <div className="w-full flex justify-center h-full">
         <div className="w-11/12 max-w-1040 flex flex-col">
           <BackButton />
-          <Suspense
-            fallback={
-              <div className="flex-grow">
-                <LoadingSpinner />
-              </div>
-            }
-          >
-            <Article articlePromise={articlePromise} />
-            <EndOfPageBackButton />
-          </Suspense>
+          <ErrorBoundary fallback={<ArticleNotFound />}>
+            <Suspense
+              fallback={
+                <div className="flex-grow">
+                  <LoadingSpinner />
+                </div>
+              }
+            >
+              <Article articlePromise={articlePromise} />
+              <EndOfPageBackButton />
+            </Suspense>
+          </ErrorBoundary>
         </div>
       </div>
     </div>

--- a/app/(routes)/articles/[slug]/page.tsx
+++ b/app/(routes)/articles/[slug]/page.tsx
@@ -58,14 +58,20 @@ export default function Page({ params }: ArticleProps) {
   const articlePromise = getArticle(params.slug);
 
   return (
-    <div className="relative">
-      <div className="w-full flex justify-center">
-        <div className="w-11/12 max-w-1040">
+    <div className="relative h-full">
+      <div className="w-full flex justify-center h-full">
+        <div className="w-11/12 max-w-1040 flex flex-col">
           <BackButton />
-          <Suspense fallback={<LoadingSpinner />}>
+          <Suspense
+            fallback={
+              <div className="flex-grow">
+                <LoadingSpinner />
+              </div>
+            }
+          >
             <Article articlePromise={articlePromise} />
+            <EndOfPageBackButton />
           </Suspense>
-          <EndOfPageBackButton />
         </div>
       </div>
     </div>

--- a/app/(routes)/articles/page.tsx
+++ b/app/(routes)/articles/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import { client } from "@/sanity/client";
 import { MobileArticleLinks } from "@components/MobileArticleLinks";
-import { ArticleData } from "@/app/(routes)/articles/[slug]/page";
+import { ArticleData } from "@components/Article";
 import { LoadingSpinner } from "@components/LoadingSpinner";
 
 const ARTICLES_QUERY = `

--- a/app/(routes)/articles/page.tsx
+++ b/app/(routes)/articles/page.tsx
@@ -1,6 +1,8 @@
+import { Suspense } from "react";
 import { client } from "@/sanity/client";
 import { MobileArticleLinks } from "@components/MobileArticleLinks";
 import { ArticleData } from "@/app/(routes)/articles/[slug]/page";
+import { LoadingSpinner } from "@components/LoadingSpinner";
 
 const ARTICLES_QUERY = `
 *[
@@ -31,5 +33,9 @@ const getArticles = async () => {
 export default function Articles() {
   const articlesPromise = getArticles();
 
-  return <MobileArticleLinks articlesPromise={articlesPromise} />;
+  return (
+    <Suspense fallback={<LoadingSpinner />}>
+      <MobileArticleLinks articlesPromise={articlesPromise} />
+    </Suspense>
+  );
 }

--- a/app/(routes)/articles/page.tsx
+++ b/app/(routes)/articles/page.tsx
@@ -20,7 +20,7 @@ const ARTICLES_QUERY = `
 `;
 
 const getArticles = async () => {
-  const res = await client.fetch<ArticleData[]>(
+  const res = client.fetch<ArticleData[]>(
     ARTICLES_QUERY,
     {},
     { next: { revalidate: 3600 } }
@@ -28,8 +28,8 @@ const getArticles = async () => {
   return res;
 };
 
-export default async function Articles() {
-  const articles = await getArticles();
+export default function Articles() {
+  const articlesPromise = getArticles();
 
-  return <MobileArticleLinks articles={articles} />;
+  return <MobileArticleLinks articlesPromise={articlesPromise} />;
 }

--- a/app/_components/Article.tsx
+++ b/app/_components/Article.tsx
@@ -122,7 +122,7 @@ export const Article = ({ articlePromise }: ArticleProps) => {
       </div>
 
       {/* Main content */}
-      <div className="w-full shadow-lg border-1 border-slate-600 p-8 sm:p-16 mb-16">
+      <div className="w-full shadow-lg border-1 border-slate-600 p-8 sm:p-16">
         {<PortableTextConverter portableText={content.mainContent} />}
       </div>
     </motion.div>

--- a/app/_components/Article.tsx
+++ b/app/_components/Article.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { use } from "react";
 import { Bebas_Neue } from "next/font/google";
 import cx from "classnames";
 import { motion } from "framer-motion";
@@ -10,21 +11,32 @@ import { PortableTextItem } from "@customTypes/PortableTextTypes";
 import { Tag } from "@components/Tag";
 import { useEffect, useState, useMemo } from "react";
 
+type Slug = {
+  current: string;
+};
+type Tag = {
+  value: string;
+};
+export type ArticleData = {
+  _createdAt: string;
+  title: string;
+  jpTitle: string;
+  slug: Slug;
+  description: string;
+  jpDescription: string;
+  tags: Tag[];
+  jpTags: Tag[];
+  mainContent: PortableTextItem[];
+  jpMainContent: PortableTextItem[];
+};
+
 const bebasNeue = Bebas_Neue({
   weight: "400",
   subsets: ["latin"],
 });
 
 type ArticleProps = {
-  createdAt: string;
-  title: string;
-  jpTitle: string;
-  description: string;
-  jpDescription: string;
-  tags: { value: string }[];
-  jpTags: { value: string }[];
-  mainContent: PortableTextItem[];
-  jpMainContent: PortableTextItem[];
+  articlePromise: Promise<ArticleData>;
 };
 
 const containerVariants = {
@@ -32,17 +44,19 @@ const containerVariants = {
   showContent: { opacity: 1, left: 0 },
 };
 
-export const Article = ({
-  createdAt,
-  title,
-  jpTitle,
-  description,
-  jpDescription,
-  tags,
-  jpTags,
-  mainContent,
-  jpMainContent,
-}: ArticleProps) => {
+export const Article = ({ articlePromise }: ArticleProps) => {
+  const {
+    _createdAt: createdAt,
+    title,
+    jpTitle,
+    description,
+    jpDescription,
+    tags,
+    jpTags,
+    mainContent,
+    jpMainContent,
+  } = use(articlePromise);
+
   const intl = useIntl();
   const { locale } = intl;
 

--- a/app/_components/ArticleNotFound.tsx
+++ b/app/_components/ArticleNotFound.tsx
@@ -1,0 +1,26 @@
+import cx from "classnames";
+import { Bebas_Neue } from "next/font/google";
+const bebasNeue = Bebas_Neue({
+  weight: "400",
+  subsets: ["latin"],
+});
+
+export const ArticleNotFound = () => {
+  return (
+    <div className="w-full h-full flex justify-center items-center">
+      <div className="relative max-w-full bg-slate-900 overflow-hidden flex items-center shadow-lg">
+        <h2
+          className={cx(
+            "text-slate-300 text-30 sm:text-72 tracking-widest p-12 pl-24 z-20 border-l-8 border-slate-300 m-16 text-shadow",
+            bebasNeue.className
+          )}
+        >
+          Article not found
+        </h2>
+        <h1 className="absolute right-12 -bottom-24 text-slate-800 font-bold text-[100px]">
+          404
+        </h1>
+      </div>
+    </div>
+  );
+};

--- a/app/_components/EndOfPageBackButton.tsx
+++ b/app/_components/EndOfPageBackButton.tsx
@@ -7,7 +7,7 @@ import Link from "next/link";
 
 export const EndOfPageBackButton = () => (
   <motion.div
-    className="flex w-full justify-center mb-16"
+    className="flex w-full justify-center py-24"
     initial={{ opacity: 0 }}
     animate={{ opacity: 1, transition: { duration: 0.6 } }}
   >

--- a/app/_components/LoadingSpinner.tsx
+++ b/app/_components/LoadingSpinner.tsx
@@ -1,0 +1,19 @@
+import styles from "./loadingSpinner.module.css";
+import cx from "classnames";
+
+type Props = {
+  size?: number;
+};
+export const LoadingSpinner = ({ size = 50 }: Props) => {
+  return (
+    <div className="flex justify-center items-center h-full w-full">
+      <div
+        className={cx(
+          "border-x-slate-900 border-y-transparent rounded-[50%]",
+          styles.spinner
+        )}
+        style={{ height: size, width: size, borderWidth: size / 10 }}
+      />
+    </div>
+  );
+};

--- a/app/_components/MobileArticleLinks.tsx
+++ b/app/_components/MobileArticleLinks.tsx
@@ -1,14 +1,16 @@
 "use client";
-import { useState, useRef, useEffect, useMemo } from "react";
+import { use, useState, useRef, useEffect, useMemo } from "react";
 import { useIntl } from "react-intl";
 import { MobileArticleLink, ArticleProps } from "./MobileArticleLink";
 import mobileArticleLinkStyles from "./mobileArticleLink.module.css";
 import { ArticleData } from "@/app/(routes)/articles/[slug]/page";
 
 type Props = {
-  articles: ArticleData[];
+  articlesPromise: Promise<ArticleData[]>;
 };
-export const MobileArticleLinks = ({ articles }: Props) => {
+export const MobileArticleLinks = ({ articlesPromise }: Props) => {
+  const articles = use(articlesPromise);
+
   const containerRef = useRef<HTMLDivElement>(null);
   const intl = useIntl();
   const { locale } = intl;

--- a/app/_components/MobileArticleLinks.tsx
+++ b/app/_components/MobileArticleLinks.tsx
@@ -3,7 +3,7 @@ import { use, useState, useRef, useEffect, useMemo } from "react";
 import { useIntl } from "react-intl";
 import { MobileArticleLink, ArticleProps } from "./MobileArticleLink";
 import mobileArticleLinkStyles from "./mobileArticleLink.module.css";
-import { ArticleData } from "@/app/(routes)/articles/[slug]/page";
+import { ArticleData } from "@components/Article";
 
 type Props = {
   articlesPromise: Promise<ArticleData[]>;

--- a/app/_components/loadingSpinner.module.css
+++ b/app/_components/loadingSpinner.module.css
@@ -1,0 +1,12 @@
+.spinner {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "next-sanity": "^9.4.2",
     "react": "^18",
     "react-dom": "^18",
+    "react-error-boundary": "^4.0.13",
     "react-icons": "^5.2.1",
     "react-intl": "^6.6.8",
     "react-syntax-highlighter": "^15.5.0",

--- a/stories/ArticleNotFound.stories.tsx
+++ b/stories/ArticleNotFound.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ArticleNotFound } from "@components/ArticleNotFound";
+
+const meta = {
+  title: "Components/ArticleNotFound",
+  component: ArticleNotFound,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {},
+  decorators: [
+    (Story) => (
+      <div className="w-screen h-screen flex justify-center items-center">
+        <div style={{ width: "500px" }}>
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ArticleNotFound>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {},
+};

--- a/stories/LoadingSpinner.stories.tsx
+++ b/stories/LoadingSpinner.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { LoadingSpinner } from "@components/LoadingSpinner";
+
+const meta = {
+  title: "Components/LoadingSpinner",
+  component: LoadingSpinner,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {},
+  decorators: [
+    (Story) => (
+      <div className="w-screen h-screen">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof LoadingSpinner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {},
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -9603,6 +9603,13 @@ react-element-to-jsx-string@^15.0.0:
     is-plain-object "5.0.0"
     react-is "18.1.0"
 
+react-error-boundary@^4.0.13:
+  version "4.0.13"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-4.0.13.tgz#80386b7b27b1131c5fbb7368b8c0d983354c7947"
+  integrity sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-icons@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-5.2.1.tgz#28c2040917b2a2eda639b0f797bff1888e018e4a"


### PR DESCRIPTION
This PR replaces the current `async` data fetching methods in the `articles/page` and `articles/[slug]` routes with React 19's new promise-based `use()` hook.

This allows us to wrap the consuming components in a Suspense boundary, and present a loading spinner. Previously, clicking a link to one of these pages would result in no visual indication that anything is happening, which is a confusing UX.